### PR TITLE
raochtest: deflake activerecord test

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -27,4 +27,5 @@ var activeRecordIgnoreList = blocklist{
 	`TestAutosaveAssociationOnAHasAndBelongsToManyAssociation#test_should_not_save_and_return_false_if_a_callback_cancelled_saving_in_either_create_or_update`: "flaky",
 	`TestAutosaveAssociationOnAHasAndBelongsToManyAssociation#test_should_not_update_children_when_parent_creation_with_no_reason`:                             "flaky",
 	`TestAutosaveAssociationOnAHasAndBelongsToManyAssociation#test_should_update_children_when_autosave_is_true_and_parent_is_new_but_child_is_not`:            "flaky",
+	`CockroachDB::FixturesTest#test_create_fixtures`:                                                                                                           "flaky",
 }


### PR DESCRIPTION
Previously, the active record test had a test flake on CockroachDB::FixturesTest#test_create_fixtures. This patch adds that test on the ignore list.

Fixes: #136460

Release note: None