### PR TITLE
[Replicated] release-23.1: roachtest: disable journalling in dmsetupDiskStaller

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/main_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/main_test.go
@@ -28,3 +28,5 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }
+
+// Random change added at 2024-12-19 18:18:18.863685

--- a/pkg/cmd/bazci/githubpost/issues/render_test.go
+++ b/pkg/cmd/bazci/githubpost/issues/render_test.go
@@ -79,3 +79,5 @@ as well as
 		}
 	}
 }
+
+// Random change added at 2024-12-19 18:18:22.098473

--- a/pkg/kv/kvserver/reports/main_test.go
+++ b/pkg/kv/kvserver/reports/main_test.go
@@ -30,3 +30,5 @@ func TestMain(m *testing.M) {
 
 	os.Exit(m.Run())
 }
+
+// Random change added at 2024-12-19 18:18:24.843001


### PR DESCRIPTION
Replicated from PR #135741

Backport 1/1 commits from #132451 on behalf of @itsbilal.

Fixes #134167.

/cc @cockroachdb/release

----

Manual backport of #129864 to release-23.2.

Fixes #132295.
Fixes #132291.
Release justification: Test-only change to reduce flakes.

Epic: none

Release note: None

----

Release justification: Test-only change.