### PR TITLE
[Replicated] release-23.1: roachtest: disable journalling in dmsetupDiskStaller

### DIFF
--- a/pkg/sql/test_file_35.go
+++ b/pkg/sql/test_file_35.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 245d4fdd
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 245d4fddb407ef1560412dfc46f484efe393af8d
+        // Added on: 2024-12-19T19:44:21.036849
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #135741

Original author: blathers-crl[bot]
Original creation date: 2024-11-19T20:33:39Z

Original reviewers: jbowens, RaduBerinde

Original description:
---
Backport 1/1 commits from #132451 on behalf of @itsbilal.

Fixes #134167.

/cc @cockroachdb/release

----

Manual backport of #129864 to release-23.2.

Fixes #132295.
Fixes #132291.
Release justification: Test-only change to reduce flakes.

Epic: none

Release note: None

----

Release justification: Test-only change.
