### PR TITLE
[Replicated] release-23.1: leaktest: ignore leaked goroutines if test was skipped

### DIFF
--- a/pkg/sql/test_file_906.go
+++ b/pkg/sql/test_file_906.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 2875e617
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 2875e617b2be742096331ffbf43060950697ae7a
+        // Added on: 2024-12-19T19:44:30.069325
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #135710

Original author: blathers-crl[bot]
Original creation date: 2024-11-19T15:34:14Z

Original reviewers: spilchen

Original description:
---
Backport 1/1 commits from #135602 on behalf of @rafiss.

/cc @cockroachdb/release

----

If a test is skipped in the middle of running, it might not have performed all the cleanup it needs to. Previously, this would cause the leak detector to report errors that we don't want to action on.

fixes https://github.com/cockroachdb/cockroach/issues/135572
Release note: None

----

Release justification: test only change
