### PR TITLE
[Replicated] release-23.1: testccl: give more memory to random schema workload unit test

### DIFF
--- a/pkg/sql/test_file_620.go
+++ b/pkg/sql/test_file_620.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 69d38450
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 69d38450fe1bce0ac33b1511c2388d55771e51ad
+        // Added on: 2024-12-19T19:44:39.238916
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #135673

Original author: blathers-crl[bot]
Original creation date: 2024-11-19T05:09:55Z

Original reviewers: annrpom

Original description:
---
Backport 1/1 commits from #135636 on behalf of @rafiss.

/cc @cockroachdb/release

----


fixes https://github.com/cockroachdb/cockroach/issues/135066
Release note: None

----

Release justification: test-only change
