### PR TITLE
[Replicated] release-23.1: colexecerror: improve the catcher due to a recent regression

### DIFF
--- a/pkg/sql/test_file_102.go
+++ b/pkg/sql/test_file_102.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit a23b6e9e
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: a23b6e9e955d8b30dd250b38d0ad5e84dd9e2cc7
+        // Added on: 2024-12-19T19:46:47.793908
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133634

Original author: blathers-crl[bot]
Original creation date: 2024-10-29T00:28:50Z

Original reviewers: michae2

Original description:
---
Backport 1/1 commits from #133620 on behalf of @yuzefovich.

/cc @cockroachdb/release

----

Earlier this year we made the vectorized panic-catcher much more efficient (in #123277) by switching from using `debug.Stack()` to `runtime.CallersFrames`. It appears that there is slight difference in the behavior between the two: the former omits frames from within the runtime (only a single frame for the panic itself is included) whereas the latter keeps the additional runtime frames. As a result, if a panic occurs due to a Go runtime internal violation (e.g. invalid interface assertion) it is no longer caught to be converted into an internal CRDB error and now crashes the server. This commit fixes this regression by skipping over the frames that belong to the Go runtime. Note that we will do so only for up to 5 frames within the runtime, so if there happens to be more deeply-nested panic there, we'll still crash the CRDB server.

Fixes: #133617.

Release note: None

----

Release justification: stability regression fix.
