### PR TITLE
[Replicated] release-23.1: gossip: adjust recovery timings to tolerate shorter lease expiration

### DIFF
--- a/pkg/sql/test_file_361.go
+++ b/pkg/sql/test_file_361.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 3316aaea
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 3316aaea8811f5f3445b5821b703e1b994c97011
+        // Added on: 2024-12-19T19:46:57.071610
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134603

Original author: nvanbenschoten
Original creation date: 2024-11-07T23:36:34Z

Original reviewers: miraradeva

Original description:
---
Backport 1/1 commits from #133300.

/cc @cockroachdb/release

---

Fixes #133159.

This commit reduces the gossip sentinel TTL from 6s to 3s, so that it is no longer aligned with the node liveness expiration of 6s. The sentinel key informs gossip whether it is connected to the primary gossip network or a partition and thus needs a short TTL so that partitions are fixed quickly. In particular, partitions need to resolve faster than the timeout (6s) or node liveness will be adversely affected, which can trigger false-positives in the `ranges.unavailable` metric.

This commit also reduces the gossip stall check interval from 2s to 1s. The stall check interval also affects how quickly gossip partitions are noticed and repaired, controlling how frequently gossip connection attempts are made. The stall check itself is very cheap, so this produces no load on the system.

Release note (bug fix): Reduce the duration of partitions in the gossip network when a node crashes in order to eliminate false positives in the `ranges.unavailable` metric.

----

Release justification: low risk change to avoid false positive alerts.
