### PR TITLE
[Replicated] release-23.1: codeowners: set release eng as owner on LICENSE and licenses

### DIFF
--- a/pkg/sql/test_file_811.go
+++ b/pkg/sql/test_file_811.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 486bbafe
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 486bbafef70e4a844e2ec14e0ddc3fc670484e85
+        // Added on: 2024-12-19T19:47:06.460880
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134732

Original author: blathers-crl[bot]
Original creation date: 2024-11-08T21:44:49Z

Original reviewers: celiala

Original description:
---
Backport 1/1 commits from #134699 on behalf of @jlinder.

/cc @cockroachdb/release

----

Epic: None
Release note: None

----

Release justification: non-production change
