### PR TITLE
[Replicated] release-23.1: licenses: remove duplicate third-party licenses

### DIFF
--- a/pkg/sql/test_file_645.go
+++ b/pkg/sql/test_file_645.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 3b3068e4
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 3b3068e4d30d536f3b11a81720e5688bd879df83
+        // Added on: 2024-12-19T19:47:28.098329
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_906.go
+++ b/pkg/sql/test_file_906.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 2d2dadee
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 2d2dadee3f874290812bc35f5c0343639d683858
+        // Added on: 2024-12-19T19:47:25.165688
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134907

Original author: jlinder
Original creation date: 2024-11-11T23:37:08Z

Original reviewers: rail

Original description:
---
Backport:
  * 1/1 commits from "licenses: remove duplicate third-party licenses" (#134608)
  * 1/1 commits from "licenses: remove unneeded notice file" (#134868)

Please see individual PRs for details.

/cc @cockroachdb/release

---

Release justification: Updating license notices for the release.
