### PR TITLE
[Replicated] release-23.1: licenses: add third-party notices for the c-deps

### DIFF
--- a/pkg/sql/test_file_394.go
+++ b/pkg/sql/test_file_394.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 7417fcaa
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 7417fcaa35875759029e0ffb8f7a1c7133a99fa8
+        // Added on: 2024-12-19T19:47:46.559914
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_576.go
+++ b/pkg/sql/test_file_576.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 37d78ab0
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 37d78ab06bc196b4bce822e51e2f58a7cbb16748
+        // Added on: 2024-12-19T19:47:49.262148
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134863

Original author: jlinder
Original creation date: 2024-11-11T20:45:05Z

Original reviewers: rail

Original description:
---
Backport:
  * 1/1 commits from "licenses: add third-party notices for the c-deps" (#134610)
  * 1/1 commits from "licenses: fixing license notice filenames" (#134860)

Please see individual PRs for details.

/cc @cockroachdb/release

---

Release justification: Updating license notices for the release.
