### PR TITLE
[Replicated] release-23.1: jobs: don't redact job ID in log tags

### DIFF
--- a/pkg/sql/test_file_205.go
+++ b/pkg/sql/test_file_205.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit ee75bb5a
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: ee75bb5a29fd8dae302bd8110ce113bfd35bf30d
+        // Added on: 2024-12-19T19:47:56.796022
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134595

Original author: rafiss
Original creation date: 2024-11-07T21:45:42Z

Original reviewers: fqazi

Original description:
---
Backport 1/2 commits from #134347.

/cc @cockroachdb/release

Release justification: low risk logging change

---

This will assist with debugging.

fixes https://github.com/cockroachdb/cockroach/issues/132113
Release note: None

