### PR TITLE
[Replicated] release-23.1: authccl: remove console API auth tests on 23.1

### DIFF
--- a/pkg/sql/test_file_457.go
+++ b/pkg/sql/test_file_457.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit d7b6d367
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: d7b6d367f40ff4ed17e5762442f8af9db974615c
+        // Added on: 2024-12-19T19:48:05.859931
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134641

Original author: pritesh-lahoti
Original creation date: 2024-11-08T11:50:49Z

Original reviewers: BabuSrithar

Original description:
---
The console API auth tests have been quite flaky since they have been backported on 23.1. The exact root cause is still unknown.

This PR removes the console API autth related tests. Have manually tested the feature out and things seem to work as expected.

Could not skip under the subtest, hence had to remove.

Fixes: #133514, #133648

Release note: None

-----

Release justification: remove flaky test
