### PR TITLE
[Replicated] release-23.1: publish-provisional-artifacts: add licenses to THIRD-PARTY-NOTICES.txt

### DIFF
--- a/pkg/sql/test_file_559.go
+++ b/pkg/sql/test_file_559.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit a7a89f0d
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: a7a89f0dddf1a08d0ceaf559a77fc9e289a6b4ae
+        // Added on: 2024-12-19T19:48:15.436271
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134712

Original author: blathers-crl[bot]
Original creation date: 2024-11-08T19:46:18Z

Original reviewers: jlinder, celiala

Original description:
---
Backport 1/1 commits from #134670 on behalf of @rail.

/cc @cockroachdb/release

----

This PR appends all third party licenses to the THIRD-PARTY-NOTICES.txt file.

Fixes: CRDB-43872
Release note: None

----

Release justification: not part of the build
