### PR TITLE
[Replicated] release-23.1: schemachanger: add PartitionName to IndexZoneConfig attr

### DIFF
--- a/pkg/sql/test_file_691.go
+++ b/pkg/sql/test_file_691.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit debda828
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: debda828eb0eac160dd8a112ffbe7684cff663ff
+        // Added on: 2024-12-19T19:48:32.461939
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134524

Original author: annrpom
Original creation date: 2024-11-07T15:40:12Z

Original reviewers: rafiss

Original description:
---
This patch adds a `PartitionName` attribute to the `IndexZoneConfig` element to uniquely identify partitions from one another. Prior to this, hitting a certain DROP path on a table with more than 1 partition on an index would panic with an undropped backref error due to our inability to distinguish these partitions from eachother.

Our code to drop these partition elements would always refer to the top-most partition element in the descsCache's `elementIndexMap` -- as the key to identify partition1 from partition2 was the same. So, partition1 would be marked `toAbsent` "twice"; while partition2 got ignored </3.

Another thing to note is that this bug is not just met for partitioned tables of the nature mentioned above -- as the `builderState`'s descriptor cache would need to be unchanged between each partition's drop.

Epic: none
Fixes: #131862

Release note (bug fix): Addressed a bug with DROP CASCADE that would occasionally panic with an undropped backref message on partitioned tables.

---

Release justification: low-risk bug fix
