### PR TITLE
[Replicated] release-23.1: workloadccl: update backup/restore syntax

### DIFF
--- a/pkg/sql/test_file_329.go
+++ b/pkg/sql/test_file_329.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit ddf026ae
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: ddf026aea1049d6dd3d89df99557bd266c6a5998
+        // Added on: 2024-12-19T19:48:41.485671
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134530

Original author: blathers-crl[bot]
Original creation date: 2024-11-07T16:11:51Z

Original reviewers: msbutler

Original description:
---
Backport 1/1 commits from #134345 on behalf of @kev-cao.

/cc @cockroachdb/release

----

The old backup/restore syntax was removed in #133610 and is no longer supported. Some workloads were not fully updated to the new syntax. This patch updates some of the old syntaxes that were missed.

Fixes: #134286

Epic: none

Release note: none

----

Release justification: test failures due to deletion of old SQL syntax
