### PR TITLE
[Replicated] release-23.1: opt: make `max-stack` opt tester option more reliable

### DIFF
--- a/pkg/sql/test_file_805.go
+++ b/pkg/sql/test_file_805.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 3ff89e9a
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 3ff89e9ae2e144a82fc844995f601fbcdc97dcc5
+        // Added on: 2024-12-19T19:48:50.740863
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134434

Original author: blathers-crl[bot]
Original creation date: 2024-11-06T18:45:39Z

Original reviewers: yuzefovich

Original description:
---
Backport 1/1 commits from #134313 on behalf of @mgartner.

/cc @cockroachdb/release

----

The `max-stack` opt tester option now runs the test command in a
separate goroutine. A fresh stack makes tests using this setting more
reliable.

It also decreases the `max-stack` of the original test that motivated
the `max-stack` option (see https://github.com/cockroachdb/cockroach/pull/132701) to 100KB, between 65KB in which the
test fails after the fix in https://github.com/cockroachdb/cockroach/pull/132701 and 135KB in which the test fails
before the fix.

Finally, the test has been disabled under `race` builds which increase
the size of stack frames and would cause this test to fail.

Epic: None

Release note: None


----

Release justification: Test-only change.
