### PR TITLE
[Replicated] release-23.1: sql: fix recently introduced data race

### DIFF
--- a/pkg/sql/test_file_48.go
+++ b/pkg/sql/test_file_48.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit f66c5973
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: f66c59737c2f653d7086d2621cf2f4513b665d41
+        // Added on: 2024-12-19T19:48:59.518793
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134243

Original author: blathers-crl[bot]
Original creation date: 2024-11-04T20:39:10Z

Original reviewers: mgartner

Original description:
---
Backport 1/1 commits from #134217 on behalf of @yuzefovich.

/cc @cockroachdb/release

----

Recently, in a5b8d06dfde18f40dabb1f3ec04f4a731641377a we introduced a possible data race. Namely, that change modifies a proto inside of the physical plan to cap the slice of types during the vectorized operator planning in order to prevent a type schema corruption due to slice aliasing. However, it's been assumed in a couple of places that the physical plan is immutable. This commit clarifies that the physical plan is immutable after its finalization and moves the capping into the finalization.

Fixes: #133934.

Release note: None

----

Release justification: bug fix.
