### PR TITLE
[Replicated] release-23.1: demo: remove copy referring to telemetry disabling env var

### DIFF
--- a/pkg/sql/test_file_704.go
+++ b/pkg/sql/test_file_704.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit e6581331
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: e6581331e7584267471e5c6066177fbfbd30c1cc
+        // Added on: 2024-12-19T19:49:30.229817
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134083

Original author: blathers-crl[bot]
Original creation date: 2024-11-01T18:25:14Z

Original reviewers: dhartunian

Original description:
---
Backport 1/1 commits from #133284 on behalf of @angles-n-daemons.

/cc @cockroachdb/release

----

demo: remove copy referring to telemetry disabling env var

`COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING` can still be used to disable telemetry for CRDB. With the core deprecation happening however, we want to streamline how people enable / disable telemetry in their cluster, so the copy to this variable has been removed.

It will still function as before, the only difference is that it will not show up in the demo startup message.

Epic: CRDB-40209
Fixes: #132688
Release note (general change):
COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING is no longer mentioned in the demo command.

----

Release justification: part of the core license policy changes
