### PR TITLE
[Replicated] release-23.1: settings: redact all string settings for diagnostics

### DIFF
--- a/pkg/sql/test_file_944.go
+++ b/pkg/sql/test_file_944.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 6622a1b7
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 6622a1b7c9d4c404b7bc59043400d935e4ed1f5f
+        // Added on: 2024-12-19T19:49:48.758505
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134063

Original author: dhartunian
Original creation date: 2024-11-01T14:19:43Z

Original reviewers: kyle-a-wong

Original description:
---
Backport 1/1 commits from #133754.

/cc @cockroachdb/release

---

Previously, the redaction logic for `Sensitive` settings in the diagnotics payload was conditional on the value of the `"server.redact_sensitive_settings.enabled"` cluster setting.

This commit modifies the behavior of `RedactedValue` used to render modified cluster settings by the `diagnostics` package to always fully redact the values of string settings and any sensitive or non- reportable settings.

Because the `MaskedSetting` struct is now in use by code in the `SHOW CLUSTER SETTING` code path, we no longer rely on it for redaction behavior of string settings.

Resolves: CRDB-43457
Epic: None

Release note (security update): all cluster settings that accept strings are now fully redacted when transmitted as part of our diagnostics telemetry. This payload includes a record of modified cluster settings and their values when they are not strings. Customers who previously applied the mitigations in Technical Advisory 133479 can safely set the value of cluster setting `server.redact_sensitive_settings.enabled` to false and turn on diagnostic reporting via the `diagnostics.reporting.enabled` cluster setting without leaking sensitive cluster settings values.

---
# Note: "sensitive" settings were introduced in 23.2 so this backport will affect non-reportable and string settings for 23.1

Release justification: removing sensitive data from diagnostics output.
