### PR TITLE
[Replicated] release-23.1: server, ui: tweak language for throttling, remove obsolete alerts, add test probe

### DIFF
--- a/pkg/sql/test_file_11.go
+++ b/pkg/sql/test_file_11.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 32bc346f
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 32bc346f86c70d9b99bbf6bc01b2f98c3a307905
+        // Added on: 2024-12-19T19:49:57.261830
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_166.go
+++ b/pkg/sql/test_file_166.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit fae26112
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: fae26112a3b9ac4c349b57264164906de2a1d32d
+        // Added on: 2024-12-19T19:50:03.353740
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_765.go
+++ b/pkg/sql/test_file_765.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 999b176e
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 999b176e572c2ed62c9042b92202b887b0aed116
+        // Added on: 2024-12-19T19:50:00.184072
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #134070

Original author: dhartunian
Original creation date: 2024-11-01T15:42:08Z

Original reviewers: angles-n-daemons

Original description:
---
Backport 3/3 commits from #133863.

/cc @cockroachdb/release

---

_Note: these 3 small changes are grouped for easy review + backporting_

----

[server: allow env var override for telemetry ping](https://github.com/cockroachdb/cockroach/commit/6f44b589f9c3978ce092cc0e94a008a8f2a3ffca) 

When testing the license throttling behavior, it's helpful to easily
override the telemetry ping timestamp. This timestamp will only be
accepted if it's smaller than the current recorded timestamp, which
reduces the chance that this ability can be used to extend the grace
period.

Epic: [CRDB-40209](https://cockroachlabs.atlassian.net/browse/CRDB-40209)
Release note: None
@[dhartunian](https://github.com/cockroachdb/cockroach/commits?author=dhartunian)
dhartunian committed 2 minutes ago

----
[ui: tweak license expiration text for throttle bar](https://github.com/cockroachdb/cockroach/commit/be48767a6108b8a98dbc01615e47e387ac62b783) 

Instead of asking a user to "renew" we tell them to "add" a new
license, which matches other language we've used.

Epic: [CRDB-40853](https://cockroachlabs.atlassian.net/browse/CRDB-40853)
Release note: None
@[dhartunian](https://github.com/cockroachdb/cockroach/commits?author=dhartunian)
dhartunian committed 1 minute ago

----
[ui: remove core deprecation notification](https://github.com/cockroachdb/cockroach/commit/3190cf8d2bf4c292c4afcddfade03c84612498c3) 

Prior to 24.3 release, we added a notification in the DB Console to
alert customers to the licensing changes and give them time to
prepare. Now that they'll be rolling out, the notice is removed since
it's no longer in the future.

Epic: [CRDB-40853](https://cockroachlabs.atlassian.net/browse/CRDB-40853)
Release note: None


----

Release justification: part of core deprecation work
