### PR TITLE
[Replicated] release-23.1: license: don't hit EnvOrDefaultInt64 in hot path

### DIFF
--- a/pkg/sql/test_file_938.go
+++ b/pkg/sql/test_file_938.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 3a515eff
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 3a515eff79df2a67068560f0d232e205a8ab7e68
+        // Added on: 2024-12-19T19:50:12.422088
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133713

Original author: blathers-crl[bot]
Original creation date: 2024-10-29T19:21:40Z

Original reviewers: mgartner

Original description:
---
Backport 1/1 commits from #133683 on behalf of @tbg.

/cc @cockroachdb/release

----

Saves 0.3%cpu on sysbench.

Fixes #133088.

Release note: None
Epic: None


----

Release justification: low risk perf improvement to new feauture
