### PR TITLE
[Replicated] release-23.1: roachprod: redirect CRDB logs utility

### DIFF
--- a/pkg/sql/test_file_918.go
+++ b/pkg/sql/test_file_918.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit ea8b4d09
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: ea8b4d09404a41c4ae2c413c138a358a1cb71d34
+        // Added on: 2024-12-19T19:50:21.384479
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_984.go
+++ b/pkg/sql/test_file_984.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 69ab5468
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 69ab5468c0c72ea131632cc61febb0324247eea1
+        // Added on: 2024-12-19T19:50:24.104204
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133968

Original author: herkolategan
Original creation date: 2024-10-31T15:28:16Z

Original reviewers: DarrylWong

Original description:
---
Backport 2/2 commits from #132586.

/cc @cockroachdb/release

---

Currently, CRDB log is configured, by roachtest, to log to a file to catch any
logs written to it during a roachtest run. This is usually from a shared test
util that uses the CRDB log. The file sink on the CRDB logger will log program
arguments by default, but this can leak sensitive information.

This PR introduces a log redirect that uses the CRDB log interceptor
functionality instead of using a file sink. This way we can avoid logging the
program arguments.

Epic: None
Release note: None

Release justification: Test only change

