### PR TITLE
[Replicated] release-23.1: opt: relax max stack size in test for stack overflow

### DIFF
--- a/pkg/sql/test_file_799.go
+++ b/pkg/sql/test_file_799.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit f7574cc5
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: f7574cc5e45fefe2f177eda73f09cc0a8bad6cd5
+        // Added on: 2024-12-19T19:51:01.011549
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133738

Original author: blathers-crl[bot]
Original creation date: 2024-10-29T20:21:44Z

Original reviewers: yuzefovich

Original description:
---
Backport 1/1 commits from #133241 on behalf of @mgartner.

/cc @cockroachdb/release

----

This commit relaxes the maximum Go stack size in bytes for a test added
in #132701 from 50KB to 125KB. The very low max stack size was causing
stack overflows to occur in unrelated functions, like parsing, in some
nightly tests. I'm hoping that more than doubling this will eliminate
the flakes.

Fixes #133212

Release note: None


----

Release justification: Test only change.
