### PR TITLE
[Replicated] release-23.1: roachtest: EveryN util without CRDB log

### DIFF
--- a/pkg/sql/test_file_152.go
+++ b/pkg/sql/test_file_152.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 342bdc92
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 342bdc92994cebd138bdcaeca414d149714b4ba7
+        // Added on: 2024-12-19T19:51:19.589190
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_262.go
+++ b/pkg/sql/test_file_262.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 66265257
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 66265257f16d4e400fa9601a494ca4ef34f42af5
+        // Added on: 2024-12-19T19:51:29.036947
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_291.go
+++ b/pkg/sql/test_file_291.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 39150c7a
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 39150c7a2e4fb9de2de1ffa8c510fde59384b11a
+        // Added on: 2024-12-19T19:51:22.981273
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_962.go
+++ b/pkg/sql/test_file_962.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 7acab62a
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 7acab62a44bc3b505ccfc700432452782f7d3365
+        // Added on: 2024-12-19T19:51:26.039702
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133668

Original author: herkolategan
Original creation date: 2024-10-29T13:13:28Z

Original reviewers: srosenberg

Original description:
---
Backport 4/4 commits from #132594.

/cc @cockroachdb/release

---

This PR removes all references to CRDB log usage in roachtest. There are still a few transitive dependencies that end up calling CRDB log. These are small enough and get redirected to a separate file if they need to be inspected. Ultimately, we want to ensure that the appropriate loggers get used in roachtests, that are supplied by the test framework. After this PR, a linter can be introduced to ban the top-level import of CRDB log from roachtest. The only remaining direct usage in roachtest is to configure CRDB log to use a file sink, but this will be updated by another PR #132586 that moves the redirect functionality alongside the roachprod logger implementation.

Informs: #131412

Epic: None
Release note: None

Release justification: Test only change
