### PR TITLE
[Replicated] release-23.1: opt: fix bugs in plan gist decoding

### DIFF
--- a/pkg/sql/test_file_384.go
+++ b/pkg/sql/test_file_384.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit e91b8f15
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: e91b8f159fd38b8938eb93601fa8ef877e9a5414
+        // Added on: 2024-12-19T19:51:50.422734
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_474.go
+++ b/pkg/sql/test_file_474.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit ed117d34
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: ed117d348ea70b6da516bde003af25e66c51fded
+        // Added on: 2024-12-19T19:51:47.237380
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133727

Original author: blathers-crl[bot]
Original creation date: 2024-10-29T19:34:19Z

Original reviewers: DrewKimball

Original description:
---
Backport 2/2 commits from #109627 on behalf of @mgartner.

/cc @cockroachdb/release

----

#### opt: fix plan gist decoding of inverted filters

Details about inverted filter nodes are not encoded in plan gists. The
plan gist decoder incorrectly assumed there were some details encoded,
and would raise an internal error whenever decoding a plan gist with an
inverted filter. This commit fixes the incorrect assumption to prevent
the internal error.

Fixes #108979

There is no release not because plan gists are an undocumented feature.

Release note: None

#### opt: fix plan gist decoding internal error

This commit fixes some cases where `crdb_internal.decode_plan_gist`
could raise internal index-out-of-bound errors when given incorrectly
formed input.

Fixes #109560

Release note: None


----

Release justification: Low-risk bug fix.
