### PR TITLE
[Replicated] release-23.1: pgwire: add more test logs to debug flaky test

### DIFF
--- a/pkg/sql/test_file_328.go
+++ b/pkg/sql/test_file_328.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 56a715c1
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 56a715c1c3412e8b1bd4ea65bb53134fadedb9bc
+        // Added on: 2024-12-19T19:52:00.276591
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133694

Original author: blathers-crl[bot]
Original creation date: 2024-10-29T17:32:12Z

Original reviewers: Dedej-Bergin

Original description:
---
Backport 1/1 commits from #133688 on behalf of @rafiss.

/cc @cockroachdb/release

----

informs https://github.com/cockroachdb/cockroach/issues/127745
informs https://github.com/cockroachdb/cockroach/issues/133360
informs https://github.com/cockroachdb/cockroach/issues/131532
informs https://github.com/cockroachdb/cockroach/issues/131110
Release note: None

----

Release justification: test only change
