### PR TITLE
[Replicated] release-23.1: roachprod: add mutex for roachprod log writers

### DIFF
--- a/pkg/sql/test_file_740.go
+++ b/pkg/sql/test_file_740.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit b6aec29c
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: b6aec29c4c2d208b0e72398985d9d3e2c76985c8
+        // Added on: 2024-12-19T19:52:10.820182
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133150

Original author: herkolategan
Original creation date: 2024-10-22T10:05:21Z

Original reviewers: nameisbhaskar

Original description:
---
Backport 1/1 commits from #132630.

/cc @cockroachdb/release

---

The roachprod logger relies on the standard log output's internal synchronization, but there are a few cases where the writers (Stdout, Stderr) are used directly. This adds a safe writer wrapper around these outputs to prevent log overlaps.

Epic: None
Release note: None

Release justification: Test-only change


