### PR TITLE
[Replicated] release-23.1: colexec: fix type schema corruption in an edge case

### DIFF
--- a/pkg/sql/test_file_198.go
+++ b/pkg/sql/test_file_198.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 18b13ad4
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 18b13ad4cf830d6d104ec16f203d53e3ff6132cd
+        // Added on: 2024-12-19T22:04:14.540922
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133758

Original author: blathers-crl[bot]
Original creation date: 2024-10-30T00:26:10Z

Original reviewers: mgartner, yuzefovich

Original description:
---
Backport 1/1 commits from #133624 on behalf of @yuzefovich.

/cc @cockroachdb/release

----

This commit fixes type schema corruption in the vectorized engine in an edge case. In particular, consider the following circumstances:
- during the physical planning, when creating a new stage of processors, we often reuse the same type slice (stored in
`InputSyncSpec.ColumnTypes`) that we get from the previous stage. In other words, we might have memory aliasing, but only on the gateway node because the remote nodes get their specs deserialized and each has its own memory allocation.
- throughout the vectorized operator planning, as of 85fd4fb4a1ede027450551545644de129a7e51c4, for each newly projected vector we append the corresponding type to the type slice we have in scope. We also capture intermediate state of the type slice by some operators (e.g. `BatchSchemaSubsetEnforcer`).
- as expected, when appending a type to the slice, if there is enough capacity, we reuse it, meaning that we often append to the slice that came to us via `InputSyncSpec.ColumnTypes`.
- now, if we have two stages of processors that happened to share the same underlying type slice with some free capacity AND we needed to append vectors for each stage, then we might corrupt the type schema captured by an operator for the earlier stage when performing vectorized planning for the later stage.

The bug is effectively the same as the comment deleted by 85fd4fb4a1ede027450551545644de129a7e51c4 outlined:
```
// As an example, consider the following scenario in the context of
// planFilterExpr method:
// 1. r.ColumnTypes={types.Bool} with len=1 and cap=4
// 2. planSelectionOperators adds another types.Int column, so
//    filterColumnTypes={types.Bool, types.Int} with len=2 and cap=4
//    Crucially, it uses exact same underlying array as r.ColumnTypes
//    uses.
// 3. we project out second column, so r.ColumnTypes={types.Bool}
// 4. later, we add another types.Float column, so
//    r.ColumnTypes={types.Bool, types.Float}, but there is enough
//    capacity in the array, so we simply overwrite the second slot
//    with the new type which corrupts filterColumnTypes to become
//    {types.Bool, types.Float}, and we can get into a runtime type
//    mismatch situation.
```
The only differences are:
- aliasing of the type slice occurs via the `InputSyncSpec.ColumnTypes` that is often used as the starting points for populating `NewColOperatorResult.ColumnTypes` which is used throughout the vectorized operator planning
- columns are "projected out" by sharing the type schema between two stages of DistSQL processors.

This commit addresses this issue by capping the slice to its length right before we get into the vectorized planning. This will make it so that if we need to append a type, then we'll make a fresh allocation, and any possible memory aliasing with a different stage of processors will be gone.

I haven't quite figured out the exact conditions that are needed for this bug to occur, but my intuition says that it should be quite rare in practice (otherwise we'd have seen this much sooner given that the offending commit was merged more than a year ago and was backported to older branches).

Fixes: #130402.

Release note (bug fix): Previously, CockroachDB could encounter an internal error of the form `interface conversion: coldata.Column is` in an edge case and this is now fixed. The bug is present in versions 22.2.13+, 23.1.9+, 23.2+.

----

Release justification: bug fix.
