### PR TITLE
[Replicated] release-23.1: sql: fix erroneous NOT NULL constraint violations in UPSERTs and refactor upsert logic

### DIFF
--- a/pkg/sql/test_file_308.go
+++ b/pkg/sql/test_file_308.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 6d5d03fb
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 6d5d03fb5c05c28f4fb566f37fd2e967fcdda06d
+        // Added on: 2024-12-19T23:08:21.854047
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133824

Original author: mgartner
Original creation date: 2024-10-30T12:09:28Z

Original reviewers: yuzefovich

Original description:
---
Backport 1/6 commits from #133671.

/cc @cockroachdb/release

---

#### sql: fix erroneous NOT NULL constraint violations in UPSERTs

Fixes #133146

Release note (bug fix): A bug has been fixed that caused incorrect NOT
NULL constraint violation errors on `UPSERT` and `INSERT .. ON CONFLICT
.. DO UPDATE` statements when those statements updated an existing row
and a subset of columns which did not include a `NOT NULL` column of the
table. This bug has been present since at least version 20.1.0.

---

Release justification: Major bug fix.
