### PR TITLE
[Replicated] release-23.1: sql/catalog: fix panic inside sequence expression parsing

### DIFF
--- a/pkg/sql/test_file_632.go
+++ b/pkg/sql/test_file_632.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 4d317057
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 4d3170575dac56649eb27c421e3c750435082633
+        // Added on: 2024-12-19T23:28:47.014884
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133866

Original author: blathers-crl[bot]
Original creation date: 2024-10-30T18:08:05Z

Original reviewers: rafiss

Original description:
---
Backport 1/1 commits from #133850 on behalf of @fqazi.

/cc @cockroachdb/release

----

Previously, if the correct overloads were not found for sequence builtins it was possible for the server to panic. This could happen when rewriting a CREATE TABLE expression with an invalid sequence builtin call. To address this, this patch updates the sequence logic to return the error instead of panicking on it.

Fixes: #133399

Release note (bug fix): Address a panic inside CREATE TABLE AS if sequence builtin expressions had invalid function overloads.

----

Release justification: low risk fix for an issue that can crash the server
