### PR TITLE
[Replicated] release-23.1: sql: check object type when revoking privilege

### DIFF
--- a/pkg/sql/test_file_749.go
+++ b/pkg/sql/test_file_749.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 0a2d0c85
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 0a2d0c852ac86b87fdfff0d78246a84236ef43d5
+        // Added on: 2024-12-20T00:06:39.331781
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #133706

Original author: blathers-crl[bot]
Original creation date: 2024-10-29T18:50:10Z

Original reviewers: Dedej-Bergin

Original description:
---
Backport 1/1 commits from #133607 on behalf of @rafiss.

/cc @cockroachdb/release

----

fixes https://github.com/cockroachdb/cockroach/issues/131157
Release note (bug fix): Fix an unhandled error that could occur when using `REVOKE ... ON SEQUENCE FROM ... user` on an object that is not a sequence.

----

Release justification: bug fix
