### PR TITLE
[Replicated] release-23.1: pgwire,authccl: use pgx for TestAuthenticationAndHBARules

### DIFF
--- a/pkg/sql/test_file_630.go
+++ b/pkg/sql/test_file_630.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 5e594e18
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 5e594e18b74cecc652b98d56c967cb53f1abcf59
+        // Added on: 2025-01-05T13:34:33.495367
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_940.go
+++ b/pkg/sql/test_file_940.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 07eba36b
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 07eba36b5be67d54ee589f64eee35c5ad5567a31
+        // Added on: 2025-01-05T13:34:36.345481
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #135178

Original author: rafiss
Original creation date: 2024-11-14T16:04:23Z

Original reviewers: souravcrl

Original description:
---
Backport 2/2 commits from #135086.

/cc @cockroachdb/release

Release justification: test only change

---

The lib/pq driver is not maintained. Since we started to see flakes related to how that driver does error handling for secure connections, we switch to pgx instead.

fixes https://github.com/cockroachdb/cockroach/issues/127745
fixes https://github.com/cockroachdb/cockroach/issues/131532
fixes https://github.com/cockroachdb/cockroach/issues/131110
fixes https://github.com/cockroachdb/cockroach/issues/133360

Release note: None

