### PR TITLE
[Replicated] release-25.1: server: skip TestDRPCSelectQuery

### DIFF
--- a/pkg/sql/test_file_884.go
+++ b/pkg/sql/test_file_884.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 1d5996cc
+    // TestFunction is a sample test function created for commit 464b8889
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 1d5996ccf54f11ffac43ba3d5c3dfdc4a3163d24
-        // Added on: 2024-12-19T19:47:16.094341
+        // Original commit SHA: 464b88899299e61c816b475d67fe1195b6806a11
+        // Added on: 2025-01-17T10:57:41.078257
         // This is a single file change for demonstration
     }
     


### PR DESCRIPTION
Replicated from original PR #139190

Original author: blathers-crl[bot]
Original creation date: 2025-01-15T23:25:11Z

Original reviewers: arulajmani

Original description:
---
Backport 1/1 commits from #139189 on behalf of @celiala.

/cc @cockroachdb/release

----

`Merged ARM64 Tests` - a dependency for building release candidates
- is failing on `TestDRPCSelectQuery/insecure=false`

Which seems to be failing release-25.1 and master:

https://teamcity.cockroachdb.com/test/8101648167209808852?currentProjectId=Cockroach_Ci_TestsAwsLinuxArm64&expandTestHistoryChartSection=true

Temporarily skipping this test to unblock the release process.

Related to: https://github.com/cockroachdb/cockroach/issues/139134
Release note: None
Epic: None
Release justification: test-only change to unblock release process.

----

Release justification:
