### PR TITLE
[Replicated] release-25.1: raft: remove fmt.printf defortify line

### DIFF
--- a/pkg/sql/test_file_46.go
+++ b/pkg/sql/test_file_46.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit c381fda7
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: c381fda7a1d383c4da472fefd71e9db9cf20502f
+        // Added on: 2025-01-17T10:58:07.184327
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139173

Original author: blathers-crl[bot]
Original creation date: 2025-01-15T19:58:45Z

Original reviewers: rafiss

Original description:
---
Backport 1/1 commits from #139154 on behalf of @iskettaneh.

/cc @cockroachdb/release

----

This commit removes a log line that was added, and it shouldn't be there.

Fixes: #139137

Release Note: None

----

Release justification: an extra log line that shouldn't be there
