### PR TITLE
[Replicated] release-25.1: clusterversion: set DevBranch=false, version=v25.1.0-beta.1

### DIFF
--- a/pkg/sql/test_file_118.go
+++ b/pkg/sql/test_file_118.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 8a0a3028
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 8a0a3028594b147496258a181d0c9e90fea40e11
+        // Added on: 2025-01-17T10:58:16.030486
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139158

Original author: blathers-crl[bot]
Original creation date: 2025-01-15T18:17:18Z

Original reviewers: mw5h, jlinder

Original description:
---
Backport 1/1 commits from #138852 on behalf of @celiala.

/cc @cockroachdb/release

----

This draft against `master` is solely to iron out CI failures ahead of next week's branch cut.

This should NOT be merged into `master` (but rather redirected and merged onto `release-25.1` as soon as we do next week's branch cut.

Runbook:
- set DevelopmentBranch = false (and version.txt to beta.1)
- run `dev generate`
- replace hard-coded mentions of `10000MM.d` with `MM.d` (e.g. 1000024.3, 1000025.1)
  - if files in `pkg/sql/catalog/systemschema_test` were changed, run:
  - `./dev test pkg/sql/catalog/systemschema_test -f=TestValidateSystemSchemaAfterBootStrap --rewrite`
  - run `./dev test pkg/sql/catalog/bootstrap --rewrite -f TestInitialValuesToString` and follow instructions from test output -- i.e. update `system hash=` and `tenant hash=` in `sql/catalog/bootstrap/testdata` -- until test passes

Release note: None
Epic: None
Release justification: release-process-only change.

----

Release justification:
