### PR TITLE
[Replicated] release-25.1: raft: ComputeLeadSupportUntil on every leader tick

### DIFF
--- a/pkg/sql/test_file_230.go
+++ b/pkg/sql/test_file_230.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 1fb19e7e
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 1fb19e7e2d407afbbc84d481648815f5e997f47a
+        // Added on: 2025-01-17T10:58:25.125305
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139156

Original author: blathers-crl[bot]
Original creation date: 2025-01-15T18:15:49Z

Original reviewers: arulajmani

Original description:
---
Backport 1/1 commits from #139151 on behalf of @iskettaneh.

/cc @cockroachdb/release

----

This commit calls ComputeLeadSupportUntil on every leader tick rather than on every leader step. If the range is idle, the leader won't have anything to step on, but it will keep ticking.

References: #139072

Release Note: None

----

Release justification: this is needed as otherwise we might not compute the LeadSupportUntil frequent enough.
