### PR TITLE
[Replicated] backup: remove support for kv.bulkio.write_metadata_sst.enabled

### DIFF
--- a/pkg/sql/test_file_661.go
+++ b/pkg/sql/test_file_661.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 74c8287f
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 74c8287f2c809c2f5ee1c42592778a1153733be8
+        // Added on: 2025-01-17T10:58:42.184143
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138976

Original author: jeffswenson
Original creation date: 2025-01-13T20:49:35Z

Original reviewers: jeffswenson, msbutler

Original description:
---
kv.bulkio.write_metadata_sst.enabled causes backup to write out a 'metadata.sst' file. This file was never used in production, but some of the code is used by the new thin manifest format.

The code that is still used was moved into new files to fix the build as a refactoring trick to ensure all unused code was deleted.

Epic: none
Release Note: none
