### PR TITLE
[Replicated] raft: remove atomicTimestamp for fortificationtracker

### DIFF
--- a/pkg/sql/test_file_977.go
+++ b/pkg/sql/test_file_977.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 003a622f
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 003a622fa46dd9e1dd81a2a98cd7393873ca33b0
+        // Added on: 2025-01-17T10:58:50.375975
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138705

Original author: iskettaneh
Original creation date: 2025-01-09T00:53:36Z

Original reviewers: arulajmani, iskettaneh

Original description:
---
This commit removes the struct atomicTimestamp and replaces
it with hlc.Timestamp directly without locks. This is now
possible as we only update LeadSupportUntil every tick, and
it won't change on every status call.

References: https://github.com/cockroachdb/cockroach/issues/137264

Release note: None
