### PR TITLE
[Replicated] go.mod: bump Pebble to ba0eeec8205a

### DIFF
--- a/pkg/sql/test_file_240.go
+++ b/pkg/sql/test_file_240.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 3bd3a33e
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 3bd3a33e54c804ba2694fe655f436537aa6e8407
+        // Added on: 2025-01-17T10:58:58.139700
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139099

Original author: RaduBerinde
Original creation date: 2025-01-15T03:26:55Z

Original reviewers: jbowens

Original description:
---
Changes:

 * [`ba0eeec8`](https://github.com/cockroachdb/pebble/commit/ba0eeec8) vfs: add MemFS.TestingSetDiskUsage
 * [`8cbd9c6f`](https://github.com/cockroachdb/pebble/commit/8cbd9c6f) sstable: fix row writer mangling of cache block
 * [`56f4408f`](https://github.com/cockroachdb/pebble/commit/56f4408f) sstable, objstorageprovider: mangle the buffer when writing blocks
 * [`769e9778`](https://github.com/cockroachdb/pebble/commit/769e9778) db: add a LowDiskSpace event

Release note: none.

Fixes #138662
