### PR TITLE
[Replicated] ccl/serverccl: revise `TestTenantVars` cpu time checks

### DIFF
--- a/pkg/sql/test_file_931.go
+++ b/pkg/sql/test_file_931.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 7aa8e515
+    // TestFunction is a sample test function created for commit 4414a36d
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 7aa8e5155c0404b08ec9d7a29ae40f0cda3244b2
-        // Added on: 2024-12-19T19:46:04.754357
+        // Original commit SHA: 4414a36dab51b4988d7e3ea7baee7c20ae9fd834
+        // Added on: 2025-01-17T10:59:21.850019
         // This is a single file change for demonstration
     }
     


### PR DESCRIPTION
Replicated from original PR #139039

Original author: xinhaoz
Original creation date: 2025-01-14T16:30:45Z

Original reviewers: kyle-a-wong

Original description:
---
Previously, this test verified that a portion of the test's user cpu time would be less than or equal to the entire tenant user cpu time up to that point. This check is flaky because there's no guarantee that the inactive tenant's cpu time will surpass the test cpu time. We now simply verify that the test cpu times are greater than or equal to the tenant metrics.

The test was likely  passing before 331596c because the reported tenant cpu time was accounting for the sql server prestart. A tenant's user cpu metrics are tracked from the time the `_status/load` endpoint is registered, and the commit above moved the router setup to occur just after the prestart.

Epic: none
Fixes: #119329

Release note: None
