### PR TITLE
[Replicated] build: disable the use of PGO in release, `roachtest`, `--cross` builds

### DIFF
--- a/pkg/sql/test_file_320.go
+++ b/pkg/sql/test_file_320.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 65519b97
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 65519b975ab1cb4d83dcde8970a006d0ceda7f70
+        // Added on: 2025-01-17T10:59:38.273576
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139092

Original author: rickystewart
Original creation date: 2025-01-15T01:04:33Z

Original reviewers: rail

Original description:
---
Epic: CRDB-41952
Release note (build change): Roll back the use of PGO for releases. We plan to implement this instead for 25.2.
