### PR TITLE
[Replicated] sql/row: use Put instead of CPut when updating value of secondary index

### DIFF
--- a/pkg/sql/test_file_297.go
+++ b/pkg/sql/test_file_297.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 19f8f611
+    // TestFunction is a sample test function created for commit aa2769a1
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 19f8f611312a6d50c140a61a3bba9b056981888e
-        // Added on: 2024-12-20T00:05:57.850614
+        // Original commit SHA: aa2769a16a965a7d5e806fb852ae1f85c133e975
+        // Added on: 2025-01-17T10:59:45.903430
         // This is a single file change for demonstration
     }
     

--- a/pkg/sql/test_file_4.go
+++ b/pkg/sql/test_file_4.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 4850f7fb
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 4850f7fbea9811a9a3046d054e164c7d188f9b53
+        // Added on: 2025-01-17T10:59:48.851595
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #137805

Original author: michae2
Original creation date: 2024-12-19T23:41:46Z

Original reviewers: yuzefovich, stevendanna

Original description:
---
**sql/row: use Put instead of CPut when updating value of secondary index**

When an UPDATE statement changes the value but not the key of a secondary index (e.g. an update to the stored columns of a secondary index) we need to write a new version of the secondary index KV with the new value.

We were using a CPutAllowingIfNotExists to do this, which verified that if the KV existed, the expected value was the value before update. But there's no need for this verification. We have other mechanisms to detect a write-write conflict with any other transaction that could have changed the value concurrently. We can simply use a Put to overwrite the previous value.

This also matches what we do for the primary index when the PK doesn't change.

Epic: None

Release note: None

---

**sql: change CPutAllowingIfNotExists with nil expValue to CPut**

CPutAllowingIfNotExists with empty expValue is equivalent to CPut with empty expValue, so change a few spots to use regular CPut. This almost gets rid of CPutAllowingIfNotExists entirely, but there is at least one spot in backfill (introduced in #138707) that needs to allow for both a non-empty expValue and non-existence of the KV.

Also drop "(expecting does not exist)" from CPut tracing, as CPut with empty expValue is now overwhelmingly the most common use of CPut. And this matches the tracing in #138707.

Epic: None

Release note: None
