### PR TITLE
[Replicated] changefeedccl: rename span-level checkpoint settings for consistency

### DIFF
--- a/pkg/sql/test_file_268.go
+++ b/pkg/sql/test_file_268.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 64f47b4d
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 64f47b4db69f374818677177278a2e4dd8c5499b
+        // Added on: 2025-01-17T11:00:02.637845
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_468.go
+++ b/pkg/sql/test_file_468.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit bf608152
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: bf608152e604253b72a65480a3ad1628065166d5
+        // Added on: 2025-01-17T10:59:59.703956
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_757.go
+++ b/pkg/sql/test_file_757.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 3c7e2358
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 3c7e2358c9be800742ac2ec0d8083622eba8d3dd
+        // Added on: 2025-01-17T10:59:56.715281
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139064

Original author: andyyang890
Original creation date: 2025-01-14T20:20:23Z

Original reviewers: asg0451

Original description:
---
See individual commits

---

Epic: CRDB-37337

---

Summary:
- `changefeed.frontier_checkpoint_max_bytes` -> `changefeed.span_checkpoint.max_bytes`
- `changefeed.frontier_checkpoint_frequency` -> `changefeed.span_checkpoint.interval`
- `changefeed.frontier_highwater_lag_checkpoint_threshold` -> `changefeed.span_checkpoint.lag_threshold`
