### PR TITLE
[Replicated] go.mod: bump Pebble to 3748221737d4

### DIFF
--- a/pkg/sql/test_file_508.go
+++ b/pkg/sql/test_file_508.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 4c8ee35d
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 4c8ee35d083948fc34a43c4dd8a9c756e73b5c9f
+        // Added on: 2025-01-17T11:00:21.692821
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138980

Original author: jbowens
Original creation date: 2025-01-13T21:11:30Z

Original reviewers: RaduBerinde

Original description:
---
Changes:

 * [`37482217`](https://github.com/cockroachdb/pebble/commit/37482217) sstable/block: add Reader type
 * [`8d3363b3`](https://github.com/cockroachdb/pebble/commit/8d3363b3) sstable/block: move category stats, read env
 * [`a18792eb`](https://github.com/cockroachdb/pebble/commit/a18792eb) sstable: use errorfs in TestIteratorErrorOnInit

Release note: none.
Epic: none.

Includes some mechanical code changes from the movement of the category stats from the `sstable` package into the `sstable/block` package.
