### PR TITLE
[Replicated] storage/disk: don't error in absence of collected states

### DIFF
--- a/pkg/sql/test_file_522.go
+++ b/pkg/sql/test_file_522.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit fab01812
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: fab0181275ad2d0428064dfe8df22367a7738723
+        // Added on: 2025-01-17T11:00:30.263990
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139079

Original author: jbowens
Original creation date: 2025-01-14T22:16:57Z

Original reviewers: RaduBerinde

Original description:
---
Previously, the absence of disk stats was considered an error by the disk monitor. In non-linux platforms, we don't have disk stats. This error was spamming the cockroach logs.

Epic: none
Release note: none
