### PR TITLE
[Replicated] spanconfigkvsubscriberccl: run expensive tests in heavy pool

### DIFF
--- a/pkg/sql/test_file_203.go
+++ b/pkg/sql/test_file_203.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 6ea502f5
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 6ea502f52e011bb0dbf962de84773c78be94b3a1
+        // Added on: 2025-01-17T11:00:57.692917
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139070

Original author: rafiss
Original creation date: 2025-01-14T21:13:03Z

Original reviewers: fqazi

Original description:
---
We have seen this timeout under race over the past few weeks, so this patch gives the test more resources under race/deadlock.

informs: https://github.com/cockroachdb/cockroach/issues/138032
Release note: None
