### PR TITLE
[Replicated] catalog/lease: WaitForInitialVersion should be version gated

### DIFF
--- a/pkg/sql/test_file_540.go
+++ b/pkg/sql/test_file_540.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 023dbc1b
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 023dbc1b552bf4073a2ffb0e6e37ba8b02de4d50
+        // Added on: 2025-01-17T11:01:13.259782
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139065

Original author: fqazi
Original creation date: 2025-01-14T20:22:19Z

Original reviewers: yuzefovich

Original description:
---
Previously, we could have mixed version configurations hang waiting for initial version of descriptors, when new objects are created. This was because prior releases of CRDB do not have logic to lease new descriptors automatically. This patch adds a version gate to enable the WaitForInitialVersion and the memo staleness optimizations once 25.1 is finalized.

Fixes: #139015

Release note: None
