### PR TITLE
[Replicated] sql: add CHECK EXTERNAL CONNECTION command

### DIFF
--- a/pkg/sql/test_file_783.go
+++ b/pkg/sql/test_file_783.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit c9ef59a0
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: c9ef59a0ebf20f925fe196b517c1b1246b08a6ea
+        // Added on: 2025-01-17T11:01:21.019588
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138696

Original author: kev-cao
Original creation date: 2025-01-08T23:08:17Z

Original reviewers: kev-cao, dt

Original description:
---
This patch adds the `CHECK EXTERNAL CONNECTION` command and replaces the old `SHOW BACKUP CONNECTION` syntax.

Epic: None

Release note: None
