### PR TITLE
[Replicated] roachtest: disable shared process rebalance/by-load roachtests

### DIFF
--- a/pkg/sql/test_file_806.go
+++ b/pkg/sql/test_file_806.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 271363e9
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 271363e9b30b5dd226ebb7acadb0298dd3d0c1c2
+        // Added on: 2025-01-17T11:01:28.452012
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139040

Original author: kvoli
Original creation date: 2025-01-14T16:38:39Z

Original reviewers: arulajmani

Original description:
---
In #129117, shared process deployments were added to the `rebalance/by-load/*/mixed-version` roachtests. Despite multiple deflaking attempts (#131787, #133681, #136115, #136116), these continue to fail weekly. The root cause is currently unknown.

Part of: #139037
Release note: None
