### PR TITLE
[Replicated] roachtest: fix single node sysbench setup

### DIFF
--- a/pkg/sql/test_file_421.go
+++ b/pkg/sql/test_file_421.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit cc8e0903
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: cc8e09034ac80a91481104dd307187fc000ff643
+        // Added on: 2025-01-17T11:01:36.993020
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139042

Original author: DarrylWong
Original creation date: 2025-01-14T16:53:02Z

Original reviewers: srosenberg, DarrylWong

Original description:
---
The single node setup was accidentally using HAProxy for the prepare step, causing it to silently fail and segfault later on. Since segfaults are an ignored error, the single node tests were silently failing.

Fixes: https://github.com/cockroachdb/cockroach/issues/139024
Epic: none
Release note: none
