### PR TITLE
[Replicated] ccl/changeedccl: Add changefeed options into nemesis tests

### DIFF
--- a/pkg/sql/test_file_671.go
+++ b/pkg/sql/test_file_671.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 7d9b214c
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 7d9b214cda7b0fda89df39522bc1750a7ab96caf
+        // Added on: 2025-01-17T11:01:44.888603
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #137947

Original author: aerfrei
Original creation date: 2024-12-23T20:27:18Z

Original reviewers: wenyihu6, rharding6373, aerfrei

Original description:
---
This work makes sure our nemesis tests for changefeeds randomize
over the options we use upon changefeed creation. This randomly adds
the key_in_value option (see below) and full_table_name option half
of the time and checks that the changefeed messages respect them in
the beforeAfter validator.

Note the following limitations: the full_table_name option, when on,
asserts that the topic in the output will be d.public.{table_name}
instead of checking for the actual name of the database/schema.

This change also does not add the key_in_value option when for the
webhook and cloudstorage sinks. Even before this change, since
key_in_value is on by default for those sinks, we remove the key
from the value in those testfeed messages for ease of testing.
Unfortunately, this makes these cases hard to test, so we leave them
out for now.

See also: https://github.com/cockroachdb/cockroach/issues/134119

Epic: [CRDB-42866](https://cockroachlabs.atlassian.net/browse/CRDB-42866)

Release note: None
