### PR TITLE
[Replicated] opt: reduce allocations when filtering histogram buckets

### DIFF
--- a/pkg/sql/test_file_484.go
+++ b/pkg/sql/test_file_484.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 34e39c0c
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 34e39c0ca538f517a07117ca56e44e5ac43240c3
+        // Added on: 2025-01-17T11:02:09.602828
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138877

Original author: mgartner
Original creation date: 2025-01-12T00:27:41Z

Original reviewers: michae2

Original description:
---
`cat.HistogramBuckets` are now returned and passed by value in
`getFilteredBucket` and `(*Histogram).addBucket`, respectively,
eliminating some heap allocations.

Also, two allocations when building spans from buckets via the
`spanBuilder` have been combined into one. The new `(*spanBuilder).init`
method simplifies the API by no longer requiring that prefix datums are
passed to every invocation of `makeSpanFromBucket`. This also reduces
redundant copying of the prefix.

Epic: None

Release note: None

