### PR TITLE
[Replicated] sql/logictest: disable column family mutations in some cases

### DIFF
--- a/pkg/sql/test_file_972.go
+++ b/pkg/sql/test_file_972.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit f7a3d5d5
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: f7a3d5d57eb5c4350ec7045df8c7b1e22f64fc0c
+        // Added on: 2025-01-17T11:02:18.390503
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139029

Original author: mgartner
Original creation date: 2025-01-14T15:32:11Z

Original reviewers: normanchenn

Original description:
---
Random column family mutations are now disabled for `CREATE TABLE`
statements with unique, hash-sharded indexes. This prevents the AST
from being reserialized with a `UNIQUE` constraint with invalid options,
instead of the original `UNIQUE INDEX`. See #65929 and #107398.

Epic: None

Release note: None

