### PR TITLE
[Replicated] testutils,kvserver: add StartExecTrace and adopt in TestPromoteNonVoterInAddVoter

### DIFF
--- a/pkg/sql/test_file_676.go
+++ b/pkg/sql/test_file_676.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit c8d3af79
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: c8d3af79b2924c5027a99e0d74ab53aa688c583e
+        // Added on: 2025-01-17T11:02:26.248075
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #139036

Original author: tbg
Original creation date: 2025-01-14T15:53:48Z

Original reviewers: arulajmani

Original description:
---
Every now and then we end up with tests that fail every once in a blue moon, and we can't reproduce at will.
https://github.com/cockroachdb/cockroach/issues/138864 was one of them, and execution traces helped a great deal.

This PR introduces a helper for unit tests that execution traces the test and keeps the trace on failure, and adopts it for one of these pesky unit tests.

The trace contains the goroutine ID in the filename. Additionally, the test's main goroutine is marked via a trace region. Sample below:

<img width="1226" alt="image" src="https://github.com/user-attachments/assets/3f641c28-64f7-4fba-9267-ddd48d8dda03" />

Closes https://github.com/cockroachdb/cockroach/issues/134383.

Epic: None
Release note: None

