### PR TITLE
[Replicated] raft: avoid allocating supportMap for every LeadSupportUntil calculation

### DIFF
--- a/pkg/sql/test_file_496.go
+++ b/pkg/sql/test_file_496.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit a785188f
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: a785188f848fcdd0ba8f9d2cc41c038df77137a9
+        // Added on: 2025-01-17T11:02:41.429041
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138374

Original author: iskettaneh
Original creation date: 2025-01-07T14:49:28Z

Original reviewers: arulajmani, iskettaneh, miraradeva

Original description:
---
This adds supportExpMap that hangs off the fortificationTracker. This is                                                                                                                                                                                  
useful to avoid allocating the map for every LeadSupportUntil                                                                                                                                                                                             
calculation. This is now possible since all the calls to                                                                                                                                                                                                  
ComputeLeadSupportUntil are done with a lock held.                                                                                                                                                                                                        
                                                                                                                                                                                                                                                          
Note that this doesn't seem to improve the performance of                                                                                                                                                                                                 
ComputeLeadSupportUntil when the number of voters are low. The reason                                                                                                                                                                                     
is that there is a go compiler optimization that seems to  make an                                                                                                                                                                                        
on-stack map allocation if the size is small.                                                                                                                                                                                                             
                                                                                                                                                                                                                                                          
References: #137264                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                          
Release note: None 
