### PR TITLE
[Replicated] cloudtestutils: refactor CheckExportStore, CheckListFiles, CheckNoPermissions

### DIFF
--- a/pkg/sql/test_file_453.go
+++ b/pkg/sql/test_file_453.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit f76f2794
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: f76f279423152185dedcd784bd9881f281a651c9
+        // Added on: 2025-01-17T11:02:55.652983
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_507.go
+++ b/pkg/sql/test_file_507.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 6622a1b7
+    // TestFunction is a sample test function created for commit 7f8c8eb8
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 6622a1b7c9d4c404b7bc59043400d935e4ed1f5f
-        // Added on: 2024-12-19T23:43:45.345217
+        // Original commit SHA: 7f8c8eb8ee3d401aa35c799450e9b1a7ba24d192
+        // Added on: 2025-01-17T11:02:52.719420
         // This is a single file change for demonstration
     }
     

--- a/pkg/sql/test_file_543.go
+++ b/pkg/sql/test_file_543.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 998ba728
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 998ba728373a8525d29304b15def8762b801b9fb
+        // Added on: 2025-01-17T11:02:49.577609
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138873

Original author: RaduBerinde
Original creation date: 2025-01-11T18:21:52Z

Original reviewers: dt

Original description:
---
This PR is taking a first step towards removing `ExternalIODir` from `cluster.Settings`.

#### cloudtestutils: refactor CheckExportStore

This change adds a `cloudtestutils.StoreInfo` structure and refactors
`CheckExportStore` to use it, making the call sites simpler and more
readable. We now pass the external IO dir explicitly through
`StoreInfo` instead of getting it from the settings.

Epic: none
Release note: None

#### cloudtestutils: refactor CheckListFiles

Refactor `CheckListFiles` and `CheckListFilesCanonical` to use
`StoreInfo`.

Epic: none
Release note: None

#### cloudtestutils: refactor CheckNoPermissions

Use `StoreInfo` for `CheckNoPermissions.`

Epic: none
Release note: None

