### PR TITLE
[Replicated] DEPS: fix build when cache clear

### DIFF
--- a/pkg/sql/test_file_896.go
+++ b/pkg/sql/test_file_896.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 6d68a681
+    // TestFunction is a sample test function created for commit d4d9811d
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 6d68a6814b4f98a30ca657e77d0c56cfe4e7f43c
-        // Added on: 2025-01-05T19:59:17.039727
+        // Original commit SHA: d4d9811d84325062306057ba4a20293be9e27a37
+        // Added on: 2025-01-17T11:03:11.801441
         // This is a single file change for demonstration
     }
     


### PR DESCRIPTION
Replicated from original PR #139041

Original author: tbg
Original creation date: 2025-01-14T16:47:01Z

Original reviewers: rickystewart

Original description:
---
This broke silently in https://github.com/cockroachdb/cockroach/pull/138283. As of that PR, 

```
$ ./dev cache --down; ./dev cache --clear; bazel clean --expunge; ./dev build short
```

fail with

```
ERROR: no such package '@@org_golang_google_genproto_googleapis//rpc/code': The repository '@@org_golang_google_genproto_googleapis' could not be resolved: Repository '@@org_golang_google_genproto_googleapis' is not defined
ERROR: /private/var/tmp/_bazel_tbg/b1346cddcc70d57afdaa90f7f09f9b2c/external/com_github_buchgr_bazel_remote/server/BUILD.bazel:3:11: no such package '@@org_golang_google_genproto_googleapis//rpc/code': The repository '@@org_golang_google_genproto_googleapis' could not be resolved: Repository '@@org_golang_google_genproto_googleapis' is not defined and referenced by '@@com_github_buchgr_bazel_remote//server:go_default_library'
ERROR: Analysis of target '@@com_github_buchgr_bazel_remote//:bazel-remote' failed; build aborted: Analysis failed
```

Now it works.

Closes https://github.com/cockroachdb/cockroach/pull/139038.

Epic: none
Release note: none
