### PR TITLE
[Replicated] roachprod: retry hostname validation on different nodes

### DIFF
--- a/pkg/sql/test_file_63.go
+++ b/pkg/sql/test_file_63.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit d4ea7302
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: d4ea7302d21f602247620f05fd0ee81a3f560246
+        // Added on: 2025-01-17T11:03:27.509982
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_701.go
+++ b/pkg/sql/test_file_701.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 6d68a681
+    // TestFunction is a sample test function created for commit b0f2b656
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 6d68a6814b4f98a30ca657e77d0c56cfe4e7f43c
-        // Added on: 2024-12-19T23:22:42.612083
+        // Original commit SHA: b0f2b656dfa2df9a182d32b1e72af4824680e453
+        // Added on: 2025-01-17T11:03:30.461939
         // This is a single file change for demonstration
     }
     


### PR DESCRIPTION
Replicated from original PR #138849

Original author: DarrylWong
Original creation date: 2025-01-10T20:30:50Z

Original reviewers: srosenberg, golgeek, DarrylWong

Original description:
---
Previously hostname validation was only attempted on the first node. If the first node reports a mismatch in names, the entire cluster should mismatch as well.

However, it's possible that the first node fails due to a transient error. In this case, we want to try other nodes as a VM being down does not mean the hostnames are wrong.

This is an important distinction for artifacts collection. If a test failed because the a VM went down, we still want to collect logs from the other nodes.

This change also bumps the timeout for fetching `debug.zip`, as we recently saw it timeout despite the collection making reasonable progress.

Epic: none
Informs: #137880
Release note: none
