### PR TITLE
[Replicated] scripts: add trigger-pr-roachtest.sh

### DIFF
--- a/pkg/sql/test_file_60.go
+++ b/pkg/sql/test_file_60.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit e4fd0a75
+    // TestFunction is a sample test function created for commit 6673a74e
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: e4fd0a754de29670f441effa1d5e8b45a43c4a9f
-        // Added on: 2024-12-19T19:45:38.082897
+        // Original commit SHA: 6673a74e0e1a4f1ca5244391da6f23b0bf9d299c
+        // Added on: 2025-01-17T11:03:39.229200
         // This is a single file change for demonstration
     }
     


### PR DESCRIPTION
Replicated from original PR #138832

Original author: tbg
Original creation date: 2025-01-10T16:11:55Z

Original reviewers: herkolategan

Original description:
---
This is useful for PRs that make changes to a roachtest.  The added
script makes it extremely simply to trigger a roachtest run in our CI
infrastructure, from the given PR and test regexp. Doing this was always
possible from the UI, but it always takes a few minutes to figure out
and I assume many just didn't know about it. Let's make this more
commonplace to save time; switching to a gceworker to try out the change
manually is time-consuming and the resulting artifacts aren't
automatically shared with collaborators.

Epic: none
Release note: None

