### PR TITLE
[Replicated] roachprod: reduce start-up lag

### DIFF
--- a/pkg/sql/test_file_198.go
+++ b/pkg/sql/test_file_198.go
@@ -2,3 +2,11 @@
     // Package sql
     package sql
 
+    // TestFunction is a sample test function created for commit 7f30eeb6
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 7f30eeb60233f9293c9b89462859f56d289275f8
+        // Added on: 2025-01-17T11:03:53.091261
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_622.go
+++ b/pkg/sql/test_file_622.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit ffd28bfa
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: ffd28bfa24cb4da377699361dc8ca8630854d6d3
+        // Added on: 2025-01-17T11:03:50.034904
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_850.go
+++ b/pkg/sql/test_file_850.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 2cda66e2
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 2cda66e2caa4099e359bffd615b5939c8f570edf
+        // Added on: 2025-01-17T11:03:47.111210
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #137916

Original author: tbg
Original creation date: 2024-12-23T13:32:37Z

Original reviewers: herkolategan, tbg, golgeek, rickystewart

Original description:
---
On my machine (which is in Europe), this brings `time roachprod --help` from `1.56s` down to to `0.06s` under the following env vars:

```
ROACHPROD_DISABLE_UPDATE_CHECK=true
ROACHPROD_DISABLED_PROVIDERS=azure
ROACHPROD_SKIP_AWSCLI_CHECK=true
```

Under these env vars, my roachprod

- no longer invokes `aws --version` on each start (python, ~400ms)
- no longer inits azure, which is >1s for me
- doesn't list the gs bucket to check for a newer roachprod binary (~800ms; doesn't exist for OSX anyway).

A better way (but one outside of my purview) for most of these would be to add caching for each of these and so to avoid the cost in the common case.

Azure is an exception, as the (wall-clock) profile below shows we're spending most of our time waiting for `GetTokenFromCLIWithParams` to return. It's not clear how to optimize this. (The AWS portion of the flamegraph is `aws --version`).

![image](https://github.com/user-attachments/assets/b4677da6-c5a5-4552-b0d5-462932f1062e)


Epic: none
