### PR TITLE
[Replicated] changefeedccl/kvfeed: pass consumer id correctly

### DIFF
--- a/pkg/sql/test_file_963.go
+++ b/pkg/sql/test_file_963.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 4bede39c
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 4bede39c31de5671678370bc878b959112720079
+        // Added on: 2025-01-17T11:04:21.629982
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138939

Original author: wenyihu6
Original creation date: 2025-01-13T17:10:59Z

Original reviewers: stevendanna, andyyang890, wenyihu6

Original description:
---
Previously, we introduced the concept of a consumer ID to prevent a single
changefeed job from over-consuming the catch-up scan quota and blocking other
consumers from making progress on the server side. However, the changefeed
client-side code requires the consumer ID to be passed again in the rangefeed
options during rangefeedFactory.Run. This was missing in the previous
PR, causing the changefeed job ID to default to zero. This patch fixes
the issue by ensuring the consumer ID is correctly passed in the
rangefeed options.

Related: https://github.com/cockroachdb/cockroach/pull/133789
Release note: none
Epic: none
