### PR TITLE
[Replicated] cli: actually drain after decommission

### DIFF
--- a/pkg/sql/test_file_103.go
+++ b/pkg/sql/test_file_103.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit fe56ffe1
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: fe56ffe13339201e50c150598006e7c9b10a5e13
+        // Added on: 2025-01-17T11:04:38.974677
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_219.go
+++ b/pkg/sql/test_file_219.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit c3260295
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: c326029525d4bf90b5f6bc453e2b566e6f6da1a0
+        // Added on: 2025-01-17T11:04:42.018338
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_368.go
+++ b/pkg/sql/test_file_368.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 19f8f611
+    // TestFunction is a sample test function created for commit a72cc4f5
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 19f8f611312a6d50c140a61a3bba9b056981888e
-        // Added on: 2025-01-05T13:40:16.384460
+        // Original commit SHA: a72cc4f5842c04873a5940acb80eec71326ccf66
+        // Added on: 2025-01-17T11:04:45.246514
         // This is a single file change for demonstration
     }
     

--- a/pkg/sql/test_file_573.go
+++ b/pkg/sql/test_file_573.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit fef82de9
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: fef82de9388939310ba825ca9731a0ef902eb393
+        // Added on: 2025-01-17T11:04:35.914853
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_583.go
+++ b/pkg/sql/test_file_583.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 43b13bf4
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 43b13bf4d34c8f2945d24de48bf84c628a47f4b7
+        // Added on: 2025-01-17T11:04:32.981817
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_851.go
+++ b/pkg/sql/test_file_851.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit a2f54657
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: a2f54657ad385e01cd1120eb77ae1b03698fcdbe
+        // Added on: 2025-01-17T11:04:29.989220
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138732

Original author: tbg
Original creation date: 2025-01-09T14:10:39Z

Original reviewers: kvoli, arulajmani

Original description:
---
I do not know how this was ever supposed to work, but the old code can not have
been intentional: it created a drain client but then did not consume from it.
This had the effect of kicking off the drain, but ~immediately cancelling the
context on the goroutine carrying it out on the decommissioning node. This PR
actually waits for the drain to complete.

There is a related issue here, though. You can't drain a node that isn't live,
so attempting to decommission a node that's down will fail on the drain step.
This is certainly true as of this PR, but should have been true before as well.

Our docs[^1] do not mention this rather large caveat at all, and it seems
strange anyway; if the node is down why would you let the failing drain get in
the way.  Really the code ought to distinguish between the case of a live and
dead node and react accordingly - this is not something this PR achieves.

Fixes https://github.com/cockroachdb/cockroach/issues/138265.
Fixes https://github.com/cockroachdb/cockroach/issues/137240.

[^1]: https://www.cockroachlabs.com/docs/v24.3/node-shutdown?filters=decommission#remove-nodes
Epic: none
Release note (ops change): the `node decommission` cli command now waits
until the target node is drained before marking it as fully
decommissioned. Previously, it would start drain but not wait, leaving
the target node briefly in a state where it would be unable to
communicate with the cluster but would still accept client requests
(which would then hang or hit unexpected errors).

