### PR TITLE
[Replicated] all: host a DRPC server and use it for node-node BatchRequests

### DIFF
--- a/pkg/sql/test_file_226.go
+++ b/pkg/sql/test_file_226.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit b8115b4b
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: b8115b4b92984dd257423993a195ee47103b4cb9
+        // Added on: 2025-01-17T11:05:15.706035
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_310.go
+++ b/pkg/sql/test_file_310.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 6a2a8132
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 6a2a8132e1ffff295df5b7c0e839d6a96ee3f7bf
+        // Added on: 2025-01-17T11:04:59.147604
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_506.go
+++ b/pkg/sql/test_file_506.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 3d8f2763
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 3d8f276362711f1431127a269ae39b9186f96823
+        // Added on: 2025-01-17T11:05:12.187305
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_657.go
+++ b/pkg/sql/test_file_657.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 6d68a681
+    // TestFunction is a sample test function created for commit 9369fd0f
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 6d68a6814b4f98a30ca657e77d0c56cfe4e7f43c
-        // Added on: 2024-12-30T12:51:11.404071
+        // Original commit SHA: 9369fd0fa9e3720f0bf9205c178f79aad1727bc1
+        // Added on: 2025-01-17T11:05:05.156817
         // This is a single file change for demonstration
     }
     

--- a/pkg/sql/test_file_684.go
+++ b/pkg/sql/test_file_684.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 917b53f9
+    // TestFunction is a sample test function created for commit b0ea57cf
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 917b53f9f4bcad346f212a6552e08f6c2082998e
-        // Added on: 2025-01-17T11:04:53.425971
+        // Original commit SHA: b0ea57cf550d1cb039d34221f9613ccbfb23da28
+        // Added on: 2025-01-17T11:05:22.988133
         // This is a single file change for demonstration
     }
     

--- a/pkg/sql/test_file_684.go
+++ b/pkg/sql/test_file_684.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 917b53f9
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 917b53f9f4bcad346f212a6552e08f6c2082998e
+        // Added on: 2025-01-17T11:04:53.425971
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_761.go
+++ b/pkg/sql/test_file_761.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 053101a7
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 053101a7f31ea4edfdd9cae2689efa34cf73466a
+        // Added on: 2025-01-17T11:04:56.265454
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_911.go
+++ b/pkg/sql/test_file_911.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 42822782
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 428227821643c53ae8dfbb8976f21de4eaae950e
+        // Added on: 2025-01-17T11:05:19.859215
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_954.go
+++ b/pkg/sql/test_file_954.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit b0ae3171
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: b0ae3171018e556096f005af3ff4930f5ac8d143
+        // Added on: 2025-01-17T11:05:09.196625
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_970.go
+++ b/pkg/sql/test_file_970.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 17231906
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 17231906e28a0ee4e374139299941e1ec3257f7f
+        // Added on: 2025-01-17T11:05:02.019450
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138368

Original author: cthumuluru-crdb
Original creation date: 2025-01-07T10:59:09Z

Original reviewers: tbg, cthumuluru-crdb

Original description:
---
drpc (github.com/storj/drpc) is a lightweight, drop-in replacement for gRPC.  Initial benchmark results from the Perf Efficiency team, using a simple ping service (github.com/cockroachlabs/perf-efficiency-team/tree/main/rpctoy),
demonstrate that switching from gRPC to drpc delivers significant performance improvements.

```
$ benchdiff --old lastmerge ./pkg/sql/tests -b -r 'Sysbench/SQL/3node/oltp_read_write' -d 1000x -c 10

name                                   old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_read_write-24    14.0ms ± 2%    14.1ms ± 1%     ~     (p=0.063 n=10+10)

name                                   old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_read_write-24    2.55MB ± 1%    2.26MB ± 2%  -11.39%  (p=0.000 n=9+9)

name                                   old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_read_write-24     17.2k ± 1%     11.7k ± 0%  -32.30%  (p=0.000 n=10+8)
```

This pull request introduces experimental support for using drpc to serve BatchRequests. The feature is disabled by default but can be enabled explicitly by setting the `COCKROACH_EXPERIMENTAL_DRPC_ENABLED` environment variable or automatically in CRDB test builds. The prototype lacks key features, such as authorization checks, interceptors, etc, and is not production-ready.

When DRPC is disabled, sever, muxer and listener mock implementations are injected. If it is enabled real implementations are used. DRPC is only used for BatchRequests. This PR also added support for pooled streaming unary operations similar to https://github.com/cockroachdb/cockroach/pull/136648.

Added unit tests to ensure:
- CRDB nodes can server BatchRequests.
- Simple queries when DRPC is enabled or disabled.

Note: drpc protocol generation is not yet integrated into the build process. Protobuf files were generated manually and committed directly to the repository.

This PR has a few parts:

- it adds a copy of drpc generated code for a service that supports unary BatchRequest.
- in `rpc.NewServerEx`, we now also set up a drpc server and return it up the stack.
- Registers BatchRequest service with both DRPC and gRPC. If DRPC is enabled, it is
used to make BatchRequests, if not gRPC is used.
- in our listener setup, we configure cmux to match on the `DRPC!!!1` header and serve the resulting listener on the drpc server. The drpc example uses `drpcmigrate.ListenMux` instead of cmux; we keep cmux but must make sure the header is read off the connection before delegating (which the drpxmigrate mux would have done for us).
- if using TLS, wrap the drpc listener with TLS config and use it to servr DRPC requests.
- add support to reuse drpc streams across unary BatchRequests. However, the DRPC implementation is not on par with the gRPC counterpart in terms of allocation optimizations.

Closes https://github.com/cockroachdb/cockroach/pull/136794.
Touches #137252.

Epic: CRDB-42584
Release note: None
