### PR TITLE
[Replicated] roachtest: fix network/authentication/nodes=4

### DIFF
--- a/pkg/sql/test_file_978.go
+++ b/pkg/sql/test_file_978.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit f42be073
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: f42be073219dbf1d306c44e5711e3b4cf24f7363
+        // Added on: 2025-01-17T11:05:31.436808
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138816

Original author: tbg
Original creation date: 2025-01-10T10:27:22Z

Original reviewers: srosenberg, miraradeva

Original description:
---
For reasons, the test starts a three node cluster, then immediately
stops it, then restarts n1 and {n2,n3} separately. It was previously
restarting n1 first, followed by `{n2,n3}`. Due to recent change
PR #138109, this no longer works since n1 doesn't have quorum and
so won't signal SQL readiness.

There's an ongoing discussion on whether this new behavior is desired,
but either way, this PR changes the test to restart {n2,n3} first (which
does have quorum, assuming we wait for full replication first, which we
now do as well), followed by n1.

Closes #138806.

Epic: none
Release note: None

