### PR TITLE
[Replicated] sql: make memo.IsStale more efficient when schema objects aren't modified

### DIFF
--- a/pkg/sql/test_file_276.go
+++ b/pkg/sql/test_file_276.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 60e09096
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 60e090960bfacbca68c420e171cf7c79c36b5459
+        // Added on: 2025-01-17T11:05:39.560570
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_292.go
+++ b/pkg/sql/test_file_292.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 61318129
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 61318129f66cc087a4f4089dd0076a9c52c56a1f
+        // Added on: 2025-01-17T11:05:42.419829
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_393.go
+++ b/pkg/sql/test_file_393.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 3c749bc7
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 3c749bc783f4558c46e7f02df383fcd0a7ac93e6
+        // Added on: 2025-01-17T11:05:48.314305
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_547.go
+++ b/pkg/sql/test_file_547.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 4365f0e8
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 4365f0e84334af508dbb594177e657b1ee6d9e31
+        // Added on: 2025-01-17T11:05:45.368623
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #137426

Original author: fqazi
Original creation date: 2024-12-13T17:25:26Z

Original reviewers: rafiss, yuzefovich, fqazi, mgartner, andy-kimball

Original description:
---
This patch speeds up memo staleness checks for prepared statements by:

1. Updates the lease manager to expose a generation ID which allows you to know if any descriptors changed
2. Updates the table stats cache to add a generation ID to determine if any new stats were added
3. Updates the IsStale check to confirm if either the generation IDs have changed, zone configs, search_path, changed or current database has changed. If everything was the same in the last execution, the full CheckDependencies can be skipped. This is only used for prepared statements.
5. Updates the schema changer logic to lease new descriptors if the schema is already leased. This allows invalidation to work within a search path if new objects are made.

Fixes: #105867


Numbers from sysbench (before these changes) using `rpsak.sh repeated`:
```
Before the changes (geomean TPS): 1121.75
After the changes (geomean TPS): 1165.47
Before the changes (geomean QPS): 22435.06
After the changes (geomean QPS): 23309.41
Percent improvement: 3.89%
```

Also from the sysbench workload numbers (from @tbg) write_only:
```
benchdiff --old lastmerge  ./pkg/sql/tests -b -r 'Sysbench/SQL/3node/oltp_write_only' -d 1000x -c 10

name                                   old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_write_only-24    4.38ms ± 1%    4.23ms ± 1%  -3.38%  (p=0.000 n=10+10)

name                                   old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_write_only-24     935kB ± 6%     933kB ± 6%    ~     (p=0.739 n=10+10)

name                                   old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_write_only-24     6.08k ± 2%     6.04k ± 3%    ~     (p=0.060 n=10+10)
```

read_only:
```
benchdiff --old lastmerge  ./pkg/sql/tests -b -r 'Sysbench/SQL/3node/oltp_read_only' -d 1000x -c 10
test binaries already exist for d2bd29e: Merge #137750
test binaries already exist for 3cc7a6c: sql: add avoid_catalog_generation_for_staleness to

  pkg=1/1 iter=10/10 cockroachdb/cockroach/pkg/sql/tests \

name                                  old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_read_only-24    7.88ms ± 1%    7.44ms ± 2%  -5.62%  (p=0.000 n=10+10)

name                                  old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_read_only-24    1.20MB ± 4%    1.19MB ± 5%    ~     (p=0.353 n=10+10)

name                                  old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_read_only-24     4.71k ± 3%     4.64k ± 3%  -1.48%  (p=0.022 n=10+10)
```
