### PR TITLE
[Replicated] sql: extend drop region for system db

### DIFF
--- a/pkg/sql/test_file_128.go
+++ b/pkg/sql/test_file_128.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 5f7e1446
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 5f7e1446c73877e5842f74ffea7d645431cfc66f
+        // Added on: 2025-01-17T11:06:17.691376
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_637.go
+++ b/pkg/sql/test_file_637.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 0107f13c
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 0107f13c84d109590b42e51bb00530cccff7e397
+        // Added on: 2025-01-17T11:06:20.584470
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #137929

Original author: annrpom
Original creation date: 2024-12-23T16:07:08Z

Original reviewers: rafiss, annrpom, fqazi

Original description:
---
This patch ensures that references to a dropping region get cleaned up for the system database.

Epic: none
Fixes: #137095

Release note: None
