### PR TITLE
[Replicated] sql/schemachanger: Add support for storing policy command and type

### DIFF
--- a/pkg/sql/test_file_518.go
+++ b/pkg/sql/test_file_518.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 0d25b695
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 0d25b695cef60834eb299a063e35e7de309ac054
+        // Added on: 2025-01-17T11:06:44.143862
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138909

Original author: spilchen
Original creation date: 2025-01-13T13:21:43Z

Original reviewers: rafiss, Dedej-Bergin, spilchen

Original description:
---
A previous commit introduced basic support for CREATE/DROP POLICY. This commit expands on that functionality by storing additional details in the policy descriptor. Specifically, it adds support for storing the policy type (restrictive or permissive) and the policy command (ALL, SELECT, INSERT, UPDATE, or DELETE).

Since neither the policy type nor the policy command will be modifiable via ALTER POLICY, these attributes are included in the Policy element within the DSC, rather than as separate elements.

Epic: CRDB-11724
Informs: #136696
Release note: None
