### PR TITLE
[Replicated] roachtest: Deflake multitenant upgrade test

### DIFF
--- a/pkg/sql/test_file_714.go
+++ b/pkg/sql/test_file_714.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 2de665c7
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 2de665c71b5d415df67fe4e99b8e5752677af238
+        // Added on: 2025-01-17T11:06:59.887975
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138233

Original author: rimadeodhar
Original creation date: 2025-01-03T18:33:53Z

Original reviewers: shubhamdhama

Original description:
---
The multitenant upgrade test enforces different test scenarios while upgrading tenants in a mixed version state. The test enforces the following cases:
1. Start storage cluster with binary version: x, cluster version: x
2. Create some tenants with binary version: x and ensure they can connect to the cluster and run a workload.
3. Using the mixed version test framework, upgrade the storage cluster with binary version: x+1, cluster version: x. In this mixed version state, create remaining tenants with binary version: x and run a workload.
4. Finalize the storage cluster. At this point, the storage cluster has binary version: x+1 and cluster version: x+1
5. Upgrade tenants with binary version: x+1 and confirm tenants can connect to the storage cluster and run a workload.

In https://github.com/cockroachdb/cockroach/pull/131847, the test was rewritten using the new mixed version test framework. However, this change exposed this test to a scenario that can cause this test to fail at step 3 above. The MVT framework also runs the mixed version test (i.e. with the tenant at the older binary version) when the cluster is in the finalizing stage. This scenario is run with a [prefixed probability](https://github.com/cockroachdb/cockroach/blob/b29d6f670b94492730eec233051cbe38a57b1ae9/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go#L633). However, if we attempt to start the tenants with the previous version (i.e. the version the cluster is being upgraded from) when the cluster is being finalized, the tenants rightfully fail to connect which the test incorrectly interprets as a failure. As a result, we would see this test fail occassionally since the test was updated to use the new MVT. This PR modifies the test to ensure that in the finalizing state, we start the tenants with the right version.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/136447
Release note: None
