### PR TITLE
[Replicated] roachtest: fix WaitForReady bugs

### DIFF
--- a/pkg/sql/test_file_544.go
+++ b/pkg/sql/test_file_544.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 0275f1f5
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 0275f1f52ebbe91e5dd7b6fbe4176977c0972283
+        // Added on: 2025-01-17T11:07:10.805264
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138977

Original author: kyle-a-wong
Original creation date: 2025-01-13T20:51:32Z

Original reviewers: DarrylWong

Original description:
---
WaitForReady was not properly handling when the deadline of a timeout context was reached while waiting for the cluster to be ready. Previously, hitting the timeout would result in the roachtest running for 10 minutes until the whole test timed out. Now, WaitForReady respects when the timeutil.RunWithTimeout context times out.

Updated WaitForReady's checkReady func to use RoachtestHTTPClient's http client when making the call to GET /health?ready=1 instead of RoachtestHTTPClient's wrapper method. This wrapper method attempts to authenticate the user if no session id exists, but this endpoint doesn't require authentication so it doesnt need to use the wrapper method.

Fixes: #138143
Resolves: #136128
Epic: None
Release note: None
