### PR TITLE
[Replicated] raft: cache LeadSupportUntil

### DIFF
--- a/pkg/sql/test_file_204.go
+++ b/pkg/sql/test_file_204.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 633a55f5
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 633a55f533a47f800fa6fabd5f5871a3d78a836a
+        // Added on: 2025-01-17T11:07:18.260720
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_785.go
+++ b/pkg/sql/test_file_785.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit d056d59a
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: d056d59a1b3ed31031c50da6d58dd1117d62e1e7
+        // Added on: 2025-01-17T11:07:21.173641
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_85.go
+++ b/pkg/sql/test_file_85.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 321cdd8a
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 321cdd8ac389eb19d271f6b3c28581e0511d00c8
+        // Added on: 2025-01-17T11:07:24.135720
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138234

Original author: iskettaneh
Original creation date: 2025-01-03T19:29:25Z

Original reviewers: arulajmani, iskettaneh

Original description:
---
This PR introduces lastComputedLeadSupportUntil, which is a cached value of LeadSupportUntil. This makes it cheaper to get LeadSupportUntil. The lastComputedLeadSupportUntil is updated on every tick, and on every fortification/config change.

References: #137264

Release note: None
