### PR TITLE
[Replicated] catalog: schema descriptor validation reads all functions under a schema

### DIFF
--- a/pkg/sql/test_file_658.go
+++ b/pkg/sql/test_file_658.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 0ad877b3
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 0ad877b389dbfd2868f8e77e972914a3b21fbdd1
+        // Added on: 2025-01-17T11:07:32.425194
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_998.go
+++ b/pkg/sql/test_file_998.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit f2d483ed
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: f2d483ed80d4d4974a7641cd0a06f2e73d1324d0
+        // Added on: 2025-01-17T11:07:35.279836
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138739

Original author: fqazi
Original creation date: 2025-01-09T15:22:24Z

Original reviewers: rafiss, annrpom, fqazi

Original description:
---
Presently, schema descriptor validation read all function descriptors under schema. This is problematic when concurrent CREATE TABLE statements referring to any function under a schema are executed will run into frequent transaction retry errors.  To address this this patch will do the following:

1. Extend the Descriptor.GetReferencedDescIDs interface to support a validation level flag, indicating which references should be returned (i.e. forward references, back references, etc..).
2. Update the schema descriptor to only return back references if they are requested
3. Update the validation logic so that mutable descriptors only get mutable validation (with back references). i.e. Not just KV read descriptors
4. Update CREATE TABLE name resolution logic to avoid mutable descriptors, and only use non-leased ones.
5. Add a new test case that validates that concurrent create statements do not run into retry errors. Note: These tests are currently disabled with multi-tenant because of: #138733


Fixes: #138384
