### PR TITLE
[Replicated] roachprod: promhelper fix project and wipe

### DIFF
--- a/pkg/sql/test_file_681.go
+++ b/pkg/sql/test_file_681.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 363ccb93
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 363ccb93e61e9479b0103e31d6fe2d07cf6154ca
+        // Added on: 2025-01-17T11:07:52.044990
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138960

Original author: golgeek
Original creation date: 2025-01-13T19:02:08Z

Original reviewers: srosenberg

Original description:
---
This PR fixes a bug introduced in #138711 and also adds deletion of Prometheus targets at cluster wipe.

Before #138711, the GCE provider defaults were defined during init(). This logic was moved to an init function to allow the `drtprod` command to define its own defaults via environment variables. This introduced a state in which where the promhelper client's defaults for `SupportedPromProject` is initialized with `gce.DefaultProject()` before this value is initialized, and no Prometheus targets are ever pushed.

This PR removes the `promhelperclient.DefaultClient` that should not be used anymore, and computing the defaults in `NewPromClient()`. This PR also delegates the checks on whether or not providers and projects are supported to the promhelperclient package to simplify the logic in the callers.

Also, prior to this PR, if an `insecure` cluster was reused as a `secure` cluster during a `roachtest` run, the promhelper client would delete the `secure` configuration during cluster destruction, but would leave the `insecure` configuration (as the promhelper clients tries to delete `secure` first, then `insecure` if not found). This was creating stale Prometheus targets.

This PR introduces the deletion of the Prometheus targets at cluster wipe to fix this.

Epic: none
Release note: None
