### PR TITLE
[Replicated] opt: optimize func dep calculations for tables with many indexes

### DIFF
--- a/pkg/sql/test_file_311.go
+++ b/pkg/sql/test_file_311.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit a577d094
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: a577d094fb1527678d8a7a84506cecba097e2b38
+        // Added on: 2025-01-17T11:08:00.693995
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_898.go
+++ b/pkg/sql/test_file_898.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 0791f3de
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 0791f3def86821b2a58653e499f52e27b3491a57
+        // Added on: 2025-01-17T11:08:03.640423
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138359

Original author: DrewKimball
Original creation date: 2025-01-07T03:23:28Z

Original reviewers: mgartner, DrewKimball

Original description:
---
#### props: add fast path for ReduceCols

This commit adds a fast path to `FuncDepSet.ReduceCols`. If the FD set has
a strict key and the key is a subset of the given columns, the columns are
immediately reduced just to the key columns. From that point the columns may
be further reduced if the set has been updated since the key was originally
calculated. Note that changes had to be made to `MakeProduct` and `MakeApply`
to ensure that the original key was invalidated before new dependencies were
added to the set.

Epic: None

Release note: None

#### opt: optimize table func deps for non-unique indexes

When a table is referenced in a query, we build a func-dep set describing
the relationships between the table columns. Among other things, we use
the index key columns for this purpose. There is no benefit considering
non-unique indexes here, so this commit skips them to avoid the extra work.
This results in a performance improvement for queries against tables with
many non-unique indexes and many columns.

Epic: None

Release note: None
