### PR TITLE
[Replicated] sql/externalcatalog: deflake TestExtractIngestExternalCatalog

### DIFF
--- a/pkg/sql/test_file_491.go
+++ b/pkg/sql/test_file_491.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit cc5e53e7
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: cc5e53e78b8ac00038865b36288d0cbaa16b720a
+        // Added on: 2025-01-17T11:08:11.783612
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138928

Original author: msbutler
Original creation date: 2025-01-13T15:47:13Z

Original reviewers: jeffswenson, msbutler

Original description:
---
Previoulsy, the test would always set sql.gc_job.wait_for_gc.interval to 250
ms, to speed up gc of a dropped table. Occasionally, the gc process would
complete so quickly that this post drop query would return no results, flaking
the test:
`SELECT name FROM crdb_internal.tables WHERE state = 'DROP'`

This patch introduce to branches this test can take:
- with fast gc, to test that the gc job was properly created
- without fast gc, to test that the dropped descriptors end up in the dropped
  state.

Fixes #138639

Release note: none
