### PR TITLE
[Replicated] roachtest: mark ORM tests that rely on DO syntax as passing

### DIFF
--- a/pkg/sql/test_file_196.go
+++ b/pkg/sql/test_file_196.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 09f4c9ce
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 09f4c9ced099fbdecb46f7663ed4de52e3074ab6
+        // Added on: 2025-01-17T11:08:19.373400
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138959

Original author: rafiss
Original creation date: 2025-01-13T18:56:40Z

Original reviewers: fqazi

Original description:
---
Since https://github.com/cockroachdb/cockroach/pull/138709 was merged, more tests began passing.

fixes https://github.com/cockroachdb/cockroach/issues/138888
fixes https://github.com/cockroachdb/cockroach/issues/138857
fixes https://github.com/cockroachdb/cockroach/issues/138863
fixes https://github.com/cockroachdb/cockroach/issues/138865
fixes https://github.com/cockroachdb/cockroach/issues/138887
Release note: None
