### PR TITLE
[Replicated] roachprod: refactor Monitor

### DIFF
--- a/pkg/sql/test_file_18.go
+++ b/pkg/sql/test_file_18.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 1b1b1b76
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 1b1b1b7632b5771da4c660b73afa1ab6c05cea49
+        // Added on: 2025-01-17T11:09:00.371411
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_201.go
+++ b/pkg/sql/test_file_201.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit b8371641
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: b8371641b129db4d2bf1efd31c2fff2d071fcda5
+        // Added on: 2025-01-17T11:08:57.489520
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_407.go
+++ b/pkg/sql/test_file_407.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 0d2b3973
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 0d2b39732491e7c4e445905ce8f38119482a7ea4
+        // Added on: 2025-01-17T11:09:09.258812
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_62.go
+++ b/pkg/sql/test_file_62.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 19f8f611
+    // TestFunction is a sample test function created for commit f2f1b2ce
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 19f8f611312a6d50c140a61a3bba9b056981888e
-        // Added on: 2024-12-19T23:17:53.497155
+        // Original commit SHA: f2f1b2cedfe58165c5443de17bc97174f1969fa1
+        // Added on: 2025-01-17T11:08:48.158642
         // This is a single file change for demonstration
     }
     

--- a/pkg/sql/test_file_627.go
+++ b/pkg/sql/test_file_627.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 78a873fd
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 78a873fd4c93dee03d64c510bf3e99c89bd70d86
+        // Added on: 2025-01-17T11:08:54.075892
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_629.go
+++ b/pkg/sql/test_file_629.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 23806329
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 23806329ea4708dfc6175876d9d56ee57bed6140
+        // Added on: 2025-01-17T11:09:06.325645
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_67.go
+++ b/pkg/sql/test_file_67.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit a09069f2
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: a09069f29564ab75b47ec63eb0ca869aaf8a9595
+        // Added on: 2025-01-17T11:08:51.086559
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_890.go
+++ b/pkg/sql/test_file_890.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit b957e65c
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: b957e65c38cf94b0ad53d89a5e47a79434901e00
+        // Added on: 2025-01-17T11:09:03.435276
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #136879

Original author: herkolategan
Original creation date: 2024-12-06T12:53:08Z

Original reviewers: herkolategan, golgeek, DarrylWong

Original description:
---
Previously, Monitor was only able to monitor processes already started. It could
not detect a new processes if it was started after monitor started monitoring.

This change uses the new monitor scripts `monitor_local.sh` &
`monitor_remote.sh` which produces a frame of processes when any cockroach
process changes occur including when a new cockroach process is started.

The logic for detecting changes in processes has been moved to the "client"
side. The scripts are now less complicated and only have the responsibility of
sending through a frame of processes. A frame consists of the cluster label,
process id, and processes status of all cockroach processes.

In addition, Monitor has been moved into its own source file for better
separation of logic. The `ignore empty nodes` functionality has also been removed,
as it is an unreliable way of detecting "empty nodes", and does not serve any purpose.

Informs: #118214
Epic: None
