### PR TITLE
[Replicated] admission: account for large flush backlog

### DIFF
--- a/pkg/sql/test_file_576.go
+++ b/pkg/sql/test_file_576.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 37d78ab0
+    // TestFunction is a sample test function created for commit 7a066c2d
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 37d78ab06bc196b4bce822e51e2f58a7cbb16748
-        // Added on: 2024-12-19T19:47:49.262148
+        // Original commit SHA: 7a066c2d5f9aa28384ec6c53ed72610131773732
+        // Added on: 2025-01-17T11:09:24.176652
         // This is a single file change for demonstration
     }
     


### PR DESCRIPTION
Replicated from original PR #138894

Original author: sumeerbhola
Original creation date: 2025-01-12T19:29:47Z

Original reviewers: sumeerbhola, aadityasondhi

Original description:
---
WAL failover permits a large flush backlog. This causes the accounted writes in admission control to be significantly larger than the bytes flushed to L0 (when the backlog is building up) and be significantly smaller when the backlog is clearing up (or when a huge flush completes, even if the backlog is stable).

This causes the write linear model to be very wrong. Additionally, we can give out unlimited elastic tokens if the current overload score is very low. This PR fixes this behavior by doing the following when the backlog is high or clearing up:
- Not adjusting the write linear model or the above-raft model (only used rarely with RACv2).
- Upper bounding the elastic tokens by the compaction bytes out of L0.

The changes here slow down the rate at which send-queues are emptied in perturbation/full/partition when the partition is removed, and there is no unnecessary queueing of regular work in the AC WorkQueues. For more details see
https://github.com/cockroachdb/cockroach/issues/138798#issuecomment-2585885553.

Fixes #138798

Epic: none

Release note: None
