### PR TITLE
[Replicated] server/admin: add job messages to job detail resp

### DIFF
--- a/pkg/sql/test_file_955.go
+++ b/pkg/sql/test_file_955.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 09977055
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 0997705533a8e7045d3bc720e63432c54145a630
+        // Added on: 2025-01-17T11:09:32.091158
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138141

Original author: dt
Original creation date: 2024-12-31T21:51:35Z

Original reviewers: kev-cao

Original description:
---
This should allow showing them on the job detail page.

Release note: none.
Epic: none.
