### PR TITLE
[Replicated] roachtest: prepare sysbench through haproxy

### DIFF
--- a/pkg/sql/test_file_426.go
+++ b/pkg/sql/test_file_426.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 9a261a66
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 9a261a669ca969557531061467539b202ffb08df
+        // Added on: 2025-01-17T11:09:39.589023
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138921

Original author: tbg
Original creation date: 2025-01-13T14:57:48Z

Original reviewers: RaduBerinde

Original description:
---
Pointing `sysbench prepare` at n1 reliably overloads n1. At time of writing, it will reliably spend the first few minutes of `sysbench run` receiving snapshots. In other words, the benchmark results don't represent actual performance.

I did some archaeology to determine why we were bypassing haproxy in the first place, and it turns out that it's because in 2018[^1] the index creations triggered by `prepare` would reliably overwhelm at least one of the nodes, which in turn would prompt `haproxy` to tear down the connections. `sysbench` would react to this by segfaulting; talking directly to n1 was a work-around.

Now that seven years have passed and we have introduced various defenses via admission control, let's try to use haproxy again during bulk loading. Ideally, we end up with much more stable benchmark results that represent CockroachDB's actual performance under this workload.

[^1]: https://github.com/cockroachdb/cockroach/issues/32738

Epic: CRDB-42584

Release note: None
