### PR TITLE
[Replicated] roachtest: cleaning up microceph cluster

### DIFF
--- a/pkg/sql/test_file_664.go
+++ b/pkg/sql/test_file_664.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit ba6e2833
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: ba6e283392b3b6edeb2489aa0b9a03a8a3f7a700
+        // Added on: 2025-01-17T11:10:26.663374
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138913

Original author: sravotto
Original creation date: 2025-01-13T13:53:16Z

Original reviewers: msbutler

Original description:
---
The microceph cluster must be removed at the end of test to allow for the node to be reused.
