### PR TITLE
[Replicated] sql/schemachanger: Implement CREATE/DROP POLICY in the DSC

### DIFF
--- a/pkg/sql/test_file_663.go
+++ b/pkg/sql/test_file_663.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit f42bceaf
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: f42bceafbff22dd4079aa7f942c241edb3c40580
+        // Added on: 2025-01-17T11:10:34.894349
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #138651

Original author: spilchen
Original creation date: 2025-01-08T16:18:22Z

Original reviewers: spilchen, Dedej-Bergin, rafiss

Original description:
---
Prior to this commit, attempts to create or drop a policy succeeded but did not write any metadata to the table descriptor. This commit introduces the first step in persisting policy metadata by storing the policy name. Future PRs will handle storing additional policy details.

The policy name is now stored in a new field within the table descriptor, and each policy is assigned a unique ID specific to the table. This commit also adds elements to the DSC to support adding and removing policy information in the descriptor. Support in the legacy schema changer has been intentionally left out.

Epic: CRDB-11724
Informs #136696
Release note: none
