### PR TITLE
[Replicated] roachprod: configure chrony on Azure

### DIFF
--- a/pkg/sql/test_file_291.go
+++ b/pkg/sql/test_file_291.go
@@ -2,11 +2,11 @@
     // Package sql
     package sql
 
-    // TestFunction is a sample test function created for commit 39150c7a
+    // TestFunction is a sample test function created for commit ba01cb2a
     func TestFunction() {
         // Test implementation
-        // Original commit SHA: 39150c7a2e4fb9de2de1ffa8c510fde59384b11a
-        // Added on: 2024-12-19T19:51:22.981273
+        // Original commit SHA: ba01cb2ac913eac2a67ba17303fd04d33b300842
+        // Added on: 2025-01-17T11:10:42.433234
         // This is a single file change for demonstration
     }
     


### PR DESCRIPTION
Replicated from original PR #138727

Original author: herkolategan
Original creation date: 2025-01-09T12:22:04Z

Original reviewers: srosenberg, DarrylWong

Original description:
---
Both GCE & AWS sets up chrony for clock synchronisation. The Azure Ubuntu VM
image has chrony set up by default, but its configuration is slightly different
from the config we use in GCS & AWS.

The Azure config also opts to use a PTP Clock Source that it configures by
setting the `refclock` in the crony config (See:
https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync). This
source seems to be unreliable, considering we have had a few clock sync issues
that prompted this change.

Unlike GCS and AWS, Azure does not provide a specific NTP server. Hence, we opt
to use Google's time-servers. And as with the other startup scripts we also do a
crony waitsync to ensure the clock is in sync before proceeding.

Our docs also suggests disabling the Hyper-V Time Synchronization device (See:
https://www.cockroachlabs.com/docs/stable/deploy-cockroachdb-on-microsoft-azure#step-3-synchronize-clocks).
This has been added as part of the start-up script.

Informs: https://github.com/cockroachdb/cockroach/issues/138726

Release note: None
Epic: None
