### PR TITLE
[Replicated] release-25.2: ui: fix table page size option bug

### DIFF
--- a/pkg/sql/test_file_95.go
+++ b/pkg/sql/test_file_95.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 0d7be1cb
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 0d7be1cb42b5bc48192ea6f1cd25d6bcb69a401a
+        // Added on: 2025-04-20T15:52:06.111712
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #144666

Original author: blathers-crl[bot]
Original creation date: 2025-04-17T22:51:01Z

Original reviewers: 

Original description:
---
Backport 1/1 commits from #144556 on behalf of @kyle-a-wong.

/cc @cockroachdb/release

----

Previously, tables that showed a page size dropdown option didn't work properly. Selecting a different page size wouldn't do anything and would stay at
whatever the default configuration was.

Now, selecting a different page size option should update the table accordingly.

For functionaly components, the pagination logic
was refactored into a `usePagination` hook to
reduce repeated code

Fixes: CC-32064
Epic:CC-31904
Release note (bug fix): Fixed bug in the UI where
tables with page size dropdown options weren't
updating when a new page size option was chosen.
Now, tables update accordingly

----

Release justification:
