### PR TITLE
[Replicated] release-25.2:  changefeedccl: fix premature shutdown due to schema change bug

### DIFF
--- a/pkg/sql/test_file_185.go
+++ b/pkg/sql/test_file_185.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 47e72ae3
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 47e72ae3ddc50bf3fb77cc6283b2a9579d7487ed
+        // Added on: 2025-04-21T14:04:00.555219
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_367.go
+++ b/pkg/sql/test_file_367.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 55453b2e
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 55453b2ec9fa56036c023e45abfdd96c81fbcde5
+        // Added on: 2025-04-21T14:04:03.835665
+        // This is a single file change for demonstration
+    }
+    

--- a/pkg/sql/test_file_768.go
+++ b/pkg/sql/test_file_768.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 9bdf7bb8
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 9bdf7bb8093b6df213bfbfadfd1e03202db47889
+        // Added on: 2025-04-21T14:04:08.032654
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #144717

Original author: blathers-crl[bot]
Original creation date: 2025-04-18T22:15:04Z

Original reviewers: 

Original description:
---
Backport 3/3 commits from #144004 on behalf of @andyyang890.

/cc @cockroachdb/release

----

Fixes #144108

Test failures on master:
Fixes #143976
Fixes #144045
Fixes #144219

Test failures on release branches (won't be fixed until PR is backported):
Informs #144287
Informs #144291
Informs #144352

---

**changefeedccl: add more verbose logging around schema changes**

This patch adds more verbose logging to the change aggregator around
receiving and emitting resolved spans to help debug recurring changefeed
schema change test flakes.

Release note: None

---

**changefeedccl: fix premature shutdown due to schema change bug**

This patch fixes a bug that could potentially cause a changefeed
to erroneously complete when one of its watched tables encounters a
schema change has been fixed.

The root cause for the bug was that if we happened to get a rangefeed
checkpoint at precisely `ts.Prev()` for some schema change timestamp
`ts`, the kv feed would deliver a resolved span with `ts` and a NONE
boundary to the change aggregator, which would advance its frontier;
then when the resolved span with `ts` and a RESTART boundary was
sent to the change aggregator, the frontier would not be advanced and
so would not be flushed to the change frontier. The change frontier
would then read a nil row from the change aggregator and shut the
changefeed down as if it had completed successfully.

This bug has been fixed by modifying the resolved span frontier
forwarding logic to consider forwarding to the current timestamp
but with a non-NONE boundary type to be advancing the frontier.

Two alternative solutions that were ruled out were:
1. Unconditionally flushing the frontier when we get a non-NONE boundary
   instead of only flushing when the frontier is advanced.
     - Problem: We would flush the frontier O(spans) number of times.
2. Making the kv feed not emit resolved events for rangefeed checkpoints
   that are at a schema change boundary.
     - Problem: We wouldn't be able to save the per-span progress at the
       schema change boundary.

Release note (bug fix): A bug that could potentially cause a changefeed
to erroneously complete when one of its watched tables encounters a
schema change has been fixed.

---

**changefeedccl/resolvedspan: update assertion for forwarding boundary** 

This patch adds an assertion that the frontier will not forward the
boundary to a different type at the same time. This assertion is
important because if it's violated, the changefeed processors will not
shut down correctly during a schema change. One potential way this
could be violated in the future is a change to how boundary types are
determined on aggregators causing different boundaries to be sent from
aggregators in a mixed-version cluster for the same schema change.

Release note: None

----

Release justification:
