### PR TITLE
[Replicated] ui: fix various bugs on db console schedules page

### DIFF
--- a/pkg/sql/test_file_512.go
+++ b/pkg/sql/test_file_512.go
@@ -1,0 +1,12 @@
+
+    // Package sql
+    package sql
+
+    // TestFunction is a sample test function created for commit 3e293ec6
+    func TestFunction() {
+        // Test implementation
+        // Original commit SHA: 3e293ec6b92c0ca386e32c15355b80de88ef7bf9
+        // Added on: 2025-04-21T14:04:33.352464
+        // This is a single file change for demonstration
+    }
+    


### PR DESCRIPTION
Replicated from original PR #144638

Original author: kyle-a-wong
Original creation date: 2025-04-17T18:10:35Z

Original reviewers: 

Original description:
---
- Updated max result size of sql query to fetch schedules
  to ensure all schedules are rendered in
  db console
- Fixed a bug where changing the "show" and "status" values
  in the url query params resulted in a "something went wrong"
  page. Now, if an invalid value is set in the "show" or "status"
  query parameters, the corresponding dropdown will reset to the
  default value. ("Show: Latest 50" and "Status: All" respectively)

Fixes: #143925, #143924
Epic: None
Release note (bug fix): Fixes bugs in the db console page:
- Previously, the schedules page only showed a subset of the total
  schedules for a cluster due to a missing parameter in the server api
  call. Now the schedules table should correctly show all schedules in
  a cluster
- Fixed a bug where manually upadting the "show" or "status" query
