### PR TITLE
[Replicated] release-24.1: sql: fix infinite loop in prepare/execute of PL/pgSQL loop

### DIFF
--- a/pkg/sql/test_file_29.go
+++ b/pkg/sql/test_file_29.go
@@ -1,0 +1,11 @@
+
+// Package sql
+package sql
+
+// TestFunction is a sample test function created for commit f72b1d29
+func TestFunction() {
+    // Test implementation
+    // Original commit SHA: f72b1d295b649fa38cc62a58395dc2a3f657764e
+    // Added on: 2025-04-22T18:28:26.744342
+    // This is a single file change for demonstration
+}


### PR DESCRIPTION
Replicated from original PR #144035

Original author: DrewKimball
Original creation date: 2025-04-08T03:57:04Z

Original reviewers: michae2, mgartner

Original description:
---
Backport 1/1 commits from #144027.

/cc @cockroachdb/release

---

We recently added unconditional copying for the body of a routine during placeholder assignment in #141596. However, we missed that a routine can recursively invoke itself, leading to an infinite loop during the copy. This commit fixes the bug by keeping track of which recursive routine definitions have been seen so far during the copying of the expression tree, and short-circuiting if one has already been seen.



Release note (bug fix): Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked  a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of 25.2 prior to v25.2.0-alpha.3.

---

Release justification: fix for node-crashing bug
